### PR TITLE
Fixed file format link to point to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains all part definitions that are shipped with the [Fritzin
 
 Parts are composed of meta-data (.fzp) and related graphics (.svg). Depending on who created them, they reside in the core folder (the "official" selection), the contrib folder (shared community contributions), or the user folder (the user's own parts).
 
-Read more on the part folder structure and file format here: [http://fritzing.org/developer/fritzing-part-format](http://fritzing.org/developer/fritzing-part-format)
+Read more on the part folder structure and file format here: [https://github.com/fritzing/fritzing-app/wiki/2.1-Part-file-format](https://github.com/fritzing/fritzing-app/wiki/2.1-Part-file-format)
 
 # Creating parts
 


### PR DESCRIPTION
Changed link to point from `http://fritzing.org/developer/fritzing-part-format` to `https://github.com/fritzing/fritzing-app/wiki/2.1-Part-file-format`