### PR TITLE
4060 - 14-stage ripple-carry binary counter/divider and oscillator

### DIFF
--- a/contrib/4060.fzp
+++ b/contrib/4060.fzp
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<module referenceFile="ULN2003A.fzp" fritzingVersion="0.3.16b.02.24.4002" moduleId="4060_e09d902e037fab8d3ef620cfedcb2d7d_1">
+<module referenceFile="4060.fzp" fritzingVersion="0.3.16b.02.24.4002" moduleId="4060_e09d902e037fab8d3ef620cfedcb2d7d_1">
  <version>1.1</version>
  <author>neutmute</author>
  <title>4060</title>
@@ -25,17 +25,17 @@ p, li { white-space: pre-wrap; }
 &lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'sans-serif';">14-stage ripple-carry binary counter/divider and oscillator&lt;/span>&lt;/p>&lt;/body>&lt;/html></description>
  <views>
   <iconView>
-   <layers image="icon/4060_6ea667f6554d373f8921b193cd351913_2_icon.svg">
+   <layers image="icon/4060_icon.svg">
     <layer layerId="icon"/>
    </layers>
   </iconView>
   <breadboardView>
-   <layers image="breadboard/4060_6ea667f6554d373f8921b193cd351913_2_breadboard.svg">
+   <layers image="breadboard/4060_breadboard.svg">
     <layer layerId="breadboard"/>
    </layers>
   </breadboardView>
   <pcbView>
-   <layers image="pcb/4060_6ea667f6554d373f8921b193cd351913_2_pcb.svg">
+   <layers image="pcb/4060_pcb.svg">
     <layer layerId="copper0"/>
     <layer layerId="silkscreen"/>
     <layer layerId="keepout"/>
@@ -45,7 +45,7 @@ p, li { white-space: pre-wrap; }
    </layers>
   </pcbView>
   <schematicView>
-   <layers image="schematic/4060_6ea667f6554d373f8921b193cd351913_2_schematic.svg">
+   <layers image="schematic/4060_schematic.svg">
     <layer layerId="schematic"/>
    </layers>
   </schematicView>

--- a/contrib/4060.fzp
+++ b/contrib/4060.fzp
@@ -1,0 +1,295 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<module referenceFile="ULN2003A.fzp" fritzingVersion="0.3.16b.02.24.4002" moduleId="4060_e09d902e037fab8d3ef620cfedcb2d7d_1">
+ <version>1.1</version>
+ <author>neutmute</author>
+ <title>4060</title>
+ <label>IC</label>
+ <date>Fri Sep 4 2015</date>
+ <tags>
+  <tag>ripple</tag>
+  <tag>divider</tag>
+  <tag>DIP</tag>
+  <tag>counter</tag>
+ </tags>
+ <properties>
+  <property name="package">DIP16 [THT]</property>
+  <property name="layer"></property>
+  <property name="variant">variant 1</property>
+  <property name="family">counter</property>
+  <property name="part number"></property>
+ </properties>
+ <description>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'sans-serif';">14-stage ripple-carry binary counter/divider and oscillator&lt;/span>&lt;/p>&lt;/body>&lt;/html></description>
+ <views>
+  <iconView>
+   <layers image="icon/4060_6ea667f6554d373f8921b193cd351913_2_icon.svg">
+    <layer layerId="icon"/>
+   </layers>
+  </iconView>
+  <breadboardView>
+   <layers image="breadboard/4060_6ea667f6554d373f8921b193cd351913_2_breadboard.svg">
+    <layer layerId="breadboard"/>
+   </layers>
+  </breadboardView>
+  <pcbView>
+   <layers image="pcb/4060_6ea667f6554d373f8921b193cd351913_2_pcb.svg">
+    <layer layerId="copper0"/>
+    <layer layerId="silkscreen"/>
+    <layer layerId="keepout"/>
+    <layer layerId="soldermask"/>
+    <layer layerId="outline"/>
+    <layer layerId="copper1"/>
+   </layers>
+  </pcbView>
+  <schematicView>
+   <layers image="schematic/4060_6ea667f6554d373f8921b193cd351913_2_schematic.svg">
+    <layer layerId="schematic"/>
+   </layers>
+  </schematicView>
+ </views>
+ <connectors>
+  <connector type="male" name="Q11" id="connector0">
+   <description>Q11</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector0pin" terminalId="connector0terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector0pin" terminalId="connector0terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector0pin" layer="copper0"/>
+     <p svgId="connector0pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q12" id="connector1">
+   <description>Q12</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector1pin" terminalId="connector1terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector1pin" terminalId="connector1terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector1pin" layer="copper0"/>
+     <p svgId="connector1pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q13" id="connector2">
+   <description>Q13</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector2pin" terminalId="connector2terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector2pin" terminalId="connector2terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector2pin" layer="copper0"/>
+     <p svgId="connector2pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q5" id="connector3">
+   <description>Q5</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector3pin" terminalId="connector3terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector3pin" terminalId="connector3terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector3pin" layer="copper0"/>
+     <p svgId="connector3pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q4" id="connector4">
+   <description>Q4</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector4pin" terminalId="connector4terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector4pin" terminalId="connector4terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector4pin" layer="copper0"/>
+     <p svgId="connector4pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q6" id="connector5">
+   <description>Q6</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector5pin" terminalId="connector5terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector5pin" terminalId="connector5terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector5pin" layer="copper0"/>
+     <p svgId="connector5pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q3" id="connector6">
+   <description>Q3</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector6pin" terminalId="connector6terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector6pin" terminalId="connector6terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector6pin" layer="copper0"/>
+     <p svgId="connector6pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="GND" id="connector7">
+   <description>Connect to the 0V (ground) of the power supply in your circuit</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector7pin" terminalId="connector7terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector7pin" terminalId="connector7terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector7pin" layer="copper0"/>
+     <p svgId="connector7pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="CEXT" id="connector8">
+   <description/>
+   <views>
+    <breadboardView>
+     <p svgId="connector8pin" terminalId="connector8terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector8pin" terminalId="connector8terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector8pin" layer="copper0"/>
+     <p svgId="connector8pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="REXT" id="connector9">
+   <description/>
+   <views>
+    <breadboardView>
+     <p svgId="connector9pin" terminalId="connector9terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector9pin" terminalId="connector9terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector9pin" layer="copper0"/>
+     <p svgId="connector9pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="RS" id="connector10">
+   <description/>
+   <views>
+    <breadboardView>
+     <p svgId="connector10pin" terminalId="connector10terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector10pin" terminalId="connector10terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector10pin" layer="copper0"/>
+     <p svgId="connector10pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="MR" id="connector11">
+   <description>MR</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector11pin" terminalId="connector11terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector11pin" terminalId="connector11terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector11pin" layer="copper0"/>
+     <p svgId="connector11pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q8" id="connector12">
+   <description>Q8</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector12pin" terminalId="connector12terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector12pin" terminalId="connector12terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector12pin" layer="copper0"/>
+     <p svgId="connector12pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q7" id="connector13">
+   <description>Q7</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector13pin" terminalId="connector13terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector13pin" terminalId="connector13terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector13pin" layer="copper0"/>
+     <p svgId="connector13pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="Q9" id="connector14">
+   <description>Q9</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector14pin" terminalId="connector14terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector14pin" terminalId="connector14terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector14pin" layer="copper0"/>
+     <p svgId="connector14pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" name="VDD" id="connector15">
+   <description>VDD</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector15pin" terminalId="connector15terminal" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector15pin" terminalId="connector15terminal" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector15pin" layer="copper0"/>
+     <p svgId="connector15pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+ </connectors>
+</module>

--- a/svg/contrib/breadboard/4060_breadboard.svg
+++ b/svg/contrib/breadboard/4060_breadboard.svg
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns="http://www.w3.org/2000/svg" width="0.8in" viewBox="0 0 800 330"  height="0.33in" x="0in" version="1.2" baseProfile="tiny" y="0in">
+    <desc >
+        <referenceFile >ULN2003A_breadboard.svg</referenceFile>
+    </desc>
+    <g  id="breadboard" gorn="0.1">
+        <rect stroke-width="0" width="800" fill="#303030"  height="270" id="middle" x="0" y="30" gorn="0.1.0"/>
+        <rect stroke-width="0" width="800" fill="#3D3D3D"  height="24.6" id="top" x="0" y="30" gorn="0.1.1"/>
+        <rect stroke-width="0" width="800" fill="#000000"  height="24.6" id="bottom" x="0" y="275.4" gorn="0.1.2"/>
+        <polygon stroke-width="0" fill="#141414"  points="800,30,792.5,54.6,792.5,275.4,800,300" id="right" gorn="0.1.3"/>
+        <polygon stroke-width="0" fill="#1F1F1F"  points="0,30,7.5,54.6,7.5,275.4,0,300" id="left" gorn="0.1.4"/>
+        <polygon stroke-width="0" fill="#1C1C1C"  points="50,115,7.5,114.6,5.6,135.8,5.6,165,50,165" id="left-upper-rect" gorn="0.1.5"/>
+        <polygon stroke-width="0" fill="#383838"  points="7.5,215.5,50,215.5,50,165,5.6,165,5.6,194.2" id="left-lower-rect" gorn="0.1.6"/>
+        <path stroke-width="0" fill="#262626"  d="M5.6,135.8l0,58.3c14.7,-1.7,26.2,-14,26.2,-29.2C31.8,149.7,20.4,137.5,5.6,135.8z" id="slot" gorn="0.1.7"/>
+        <path stroke-width="0" fill="#303030"  d="M7.5,54.6L7.5,114.5c23.8,4.5,41.9,25.3,41.9,50.4c0,25.1,-18,46,-41.9,50.5L7.5,215.5l50,0L57.5,54.6L7.5,54.6z" id="cover" gorn="0.1.8"/>
+        <circle stroke-width="0" cy="234.7" fill="#212121"  r="20.6" cx="65"/>
+        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">ULN2003A</text>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector0pin" x="35" y="286.6" gorn="0.1.11"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector0terminal" x="35" y="300" gorn="0.1.12"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="35,286.6,35,306.6,65,306.6,85,297.4,85,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector15pin" x="35" y="0" gorn="0.1.14"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector15terminal" x="35" y="0" gorn="0.1.15"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="85,43.4,85,32.6,65,23.4,35,23.4,35,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector7pin" x="735" y="286.6" gorn="0.1.17"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector7terminal" x="735" y="300" gorn="0.1.18"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="715,286.6,715,297.4,735,306.6,765,306.6,765,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector8pin" x="735" y="0" gorn="0.1.20"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector8terminal" x="735" y="0" gorn="0.1.21"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="765,43.4,765,23.4,735,23.4,715,32.6,715,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector1pin" x="135" y="286.6" gorn="0.1.23"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector1terminal" x="135" y="300" gorn="0.1.24"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="115,286.6,115,297.4,135,306.6,165,306.6,185,297.4,185,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector14pin" x="135" y="0" gorn="0.1.26"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector14terminal" x="135" y="0" gorn="0.1.27"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="185,43.4,185,32.6,165,23.4,135,23.4,115,32.6,115,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector2pin" x="235" y="286.6" gorn="0.1.29"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector2terminal" x="235" y="300" gorn="0.1.30"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="215,286.6,215,297.4,235,306.6,265,306.6,285,297.4,285,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector13pin" x="235" y="0" gorn="0.1.32"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector13terminal" x="235" y="0" gorn="0.1.33"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="285,43.4,285,32.6,265,23.4,235,23.4,215,32.6,215,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector3pin" x="335" y="286.6" gorn="0.1.35"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector3terminal" x="335" y="300" gorn="0.1.36"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="315,286.6,315,297.4,335,306.6,365,306.6,385,297.4,385,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector12pin" x="335" y="0" gorn="0.1.38"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector12terminal" x="335" y="0" gorn="0.1.39"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="385,43.4,385,32.6,365,23.4,335,23.4,315,32.6,315,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector4pin" x="435" y="286.6" gorn="0.1.41"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector4terminal" x="435" y="300" gorn="0.1.42"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="415,286.6,415,297.4,435,306.6,465,306.6,485,297.4,485,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector11pin" x="435" y="0" gorn="0.1.44"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector11terminal" x="435" y="0" gorn="0.1.45"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="485,43.4,485,32.6,465,23.4,435,23.4,415,32.6,415,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector5pin" x="535" y="286.6" gorn="0.1.47"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector5terminal" x="535" y="300" gorn="0.1.48"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="515,286.6,515,297.4,535,306.6,565,306.6,585,297.4,585,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector10pin" x="535" y="0" gorn="0.1.50"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector10terminal" x="535" y="0" gorn="0.1.51"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="585,43.4,585,32.6,565,23.4,535,23.4,515,32.6,515,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector6pin" x="635" y="286.6" gorn="0.1.53"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector6terminal" x="635" y="300" gorn="0.1.54"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="615,286.6,615,297.4,635,306.6,665,306.6,685,297.4,685,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector9pin" x="635" y="0" gorn="0.1.56"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector9terminal" x="635" y="0" gorn="0.1.57"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="685,43.4,685,32.6,665,23.4,635,23.4,615,32.6,615,43.4"/>
+    </g>
+</svg>

--- a/svg/contrib/breadboard/4060_breadboard.svg
+++ b/svg/contrib/breadboard/4060_breadboard.svg
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="0.8in" viewBox="0 0 800 330"  height="0.33in" x="0in" version="1.2" baseProfile="tiny" y="0in">
     <desc >
-        <referenceFile >ULN2003A_breadboard.svg</referenceFile>
+        <referenceFile >4060_breadboard.svg</referenceFile>
     </desc>
     <g  id="breadboard" gorn="0.1">
         <rect stroke-width="0" width="800" fill="#303030"  height="270" id="middle" x="0" y="30" gorn="0.1.0"/>
@@ -14,7 +14,7 @@
         <path stroke-width="0" fill="#262626"  d="M5.6,135.8l0,58.3c14.7,-1.7,26.2,-14,26.2,-29.2C31.8,149.7,20.4,137.5,5.6,135.8z" id="slot" gorn="0.1.7"/>
         <path stroke-width="0" fill="#303030"  d="M7.5,54.6L7.5,114.5c23.8,4.5,41.9,25.3,41.9,50.4c0,25.1,-18,46,-41.9,50.5L7.5,215.5l50,0L57.5,54.6L7.5,54.6z" id="cover" gorn="0.1.8"/>
         <circle stroke-width="0" cy="234.7" fill="#212121"  r="20.6" cx="65"/>
-        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">ULN2003A</text>
+        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">4060</text>
         <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector0pin" x="35" y="286.6" gorn="0.1.11"/>
         <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector0terminal" x="35" y="300" gorn="0.1.12"/>
         <polygon stroke-width="0" fill="#8C8C8C"  points="35,286.6,35,306.6,65,306.6,85,297.4,85,286.6"/>

--- a/svg/contrib/icon/4060_icon.svg
+++ b/svg/contrib/icon/4060_icon.svg
@@ -1,0 +1,67 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns="http://www.w3.org/2000/svg" width="0.8in" viewBox="0 0 800 330"  height="0.33in" x="0in" version="1.2" baseProfile="tiny" y="0in">
+    <desc >
+        <referenceFile >ULN2003A_breadboard.svg</referenceFile>
+    </desc>
+    <g  id="breadboard" gorn="0.1">
+        <rect stroke-width="0" width="800" fill="#303030"  height="270" id="middle" x="0" y="30" gorn="0.1.0"/>
+        <rect stroke-width="0" width="800" fill="#3D3D3D"  height="24.6" id="top" x="0" y="30" gorn="0.1.1"/>
+        <rect stroke-width="0" width="800" fill="#000000"  height="24.6" id="bottom" x="0" y="275.4" gorn="0.1.2"/>
+        <polygon stroke-width="0" fill="#141414"  points="800,30,792.5,54.6,792.5,275.4,800,300" id="right" gorn="0.1.3"/>
+        <polygon stroke-width="0" fill="#1F1F1F"  points="0,30,7.5,54.6,7.5,275.4,0,300" id="left" gorn="0.1.4"/>
+        <polygon stroke-width="0" fill="#1C1C1C"  points="50,115,7.5,114.6,5.6,135.8,5.6,165,50,165" id="left-upper-rect" gorn="0.1.5"/>
+        <polygon stroke-width="0" fill="#383838"  points="7.5,215.5,50,215.5,50,165,5.6,165,5.6,194.2" id="left-lower-rect" gorn="0.1.6"/>
+        <path stroke-width="0" fill="#262626"  d="M5.6,135.8l0,58.3c14.7,-1.7,26.2,-14,26.2,-29.2C31.8,149.7,20.4,137.5,5.6,135.8z" id="slot" gorn="0.1.7"/>
+        <path stroke-width="0" fill="#303030"  d="M7.5,54.6L7.5,114.5c23.8,4.5,41.9,25.3,41.9,50.4c0,25.1,-18,46,-41.9,50.5L7.5,215.5l50,0L57.5,54.6L7.5,54.6z" id="cover" gorn="0.1.8"/>
+        <circle stroke-width="0" cy="234.7" fill="#212121"  r="20.6" cx="65"/>
+        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">ULN2003A</text>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector0pin" x="35" y="286.6" gorn="0.1.11"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector0terminal" x="35" y="300" gorn="0.1.12"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="35,286.6,35,306.6,65,306.6,85,297.4,85,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector15pin" x="35" y="0" gorn="0.1.14"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector15terminal" x="35" y="0" gorn="0.1.15"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="85,43.4,85,32.6,65,23.4,35,23.4,35,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector7pin" x="735" y="286.6" gorn="0.1.17"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector7terminal" x="735" y="300" gorn="0.1.18"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="715,286.6,715,297.4,735,306.6,765,306.6,765,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector8pin" x="735" y="0" gorn="0.1.20"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector8terminal" x="735" y="0" gorn="0.1.21"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="765,43.4,765,23.4,735,23.4,715,32.6,715,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector1pin" x="135" y="286.6" gorn="0.1.23"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector1terminal" x="135" y="300" gorn="0.1.24"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="115,286.6,115,297.4,135,306.6,165,306.6,185,297.4,185,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector14pin" x="135" y="0" gorn="0.1.26"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector14terminal" x="135" y="0" gorn="0.1.27"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="185,43.4,185,32.6,165,23.4,135,23.4,115,32.6,115,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector2pin" x="235" y="286.6" gorn="0.1.29"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector2terminal" x="235" y="300" gorn="0.1.30"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="215,286.6,215,297.4,235,306.6,265,306.6,285,297.4,285,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector13pin" x="235" y="0" gorn="0.1.32"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector13terminal" x="235" y="0" gorn="0.1.33"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="285,43.4,285,32.6,265,23.4,235,23.4,215,32.6,215,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector3pin" x="335" y="286.6" gorn="0.1.35"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector3terminal" x="335" y="300" gorn="0.1.36"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="315,286.6,315,297.4,335,306.6,365,306.6,385,297.4,385,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector12pin" x="335" y="0" gorn="0.1.38"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector12terminal" x="335" y="0" gorn="0.1.39"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="385,43.4,385,32.6,365,23.4,335,23.4,315,32.6,315,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector4pin" x="435" y="286.6" gorn="0.1.41"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector4terminal" x="435" y="300" gorn="0.1.42"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="415,286.6,415,297.4,435,306.6,465,306.6,485,297.4,485,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector11pin" x="435" y="0" gorn="0.1.44"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector11terminal" x="435" y="0" gorn="0.1.45"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="485,43.4,485,32.6,465,23.4,435,23.4,415,32.6,415,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector5pin" x="535" y="286.6" gorn="0.1.47"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector5terminal" x="535" y="300" gorn="0.1.48"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="515,286.6,515,297.4,535,306.6,565,306.6,585,297.4,585,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector10pin" x="535" y="0" gorn="0.1.50"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector10terminal" x="535" y="0" gorn="0.1.51"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="585,43.4,585,32.6,565,23.4,535,23.4,515,32.6,515,43.4"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector6pin" x="635" y="286.6" gorn="0.1.53"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector6terminal" x="635" y="300" gorn="0.1.54"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="615,286.6,615,297.4,635,306.6,665,306.6,685,297.4,685,286.6"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector9pin" x="635" y="0" gorn="0.1.56"/>
+        <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector9terminal" x="635" y="0" gorn="0.1.57"/>
+        <polygon stroke-width="0" fill="#8C8C8C"  points="685,43.4,685,32.6,665,23.4,635,23.4,615,32.6,615,43.4"/>
+    </g>
+</svg>

--- a/svg/contrib/icon/4060_icon.svg
+++ b/svg/contrib/icon/4060_icon.svg
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="0.8in" viewBox="0 0 800 330"  height="0.33in" x="0in" version="1.2" baseProfile="tiny" y="0in">
     <desc >
-        <referenceFile >ULN2003A_breadboard.svg</referenceFile>
+        <referenceFile >4060_breadboard.svg</referenceFile>
     </desc>
     <g  id="breadboard" gorn="0.1">
         <rect stroke-width="0" width="800" fill="#303030"  height="270" id="middle" x="0" y="30" gorn="0.1.0"/>
@@ -14,7 +14,7 @@
         <path stroke-width="0" fill="#262626"  d="M5.6,135.8l0,58.3c14.7,-1.7,26.2,-14,26.2,-29.2C31.8,149.7,20.4,137.5,5.6,135.8z" id="slot" gorn="0.1.7"/>
         <path stroke-width="0" fill="#303030"  d="M7.5,54.6L7.5,114.5c23.8,4.5,41.9,25.3,41.9,50.4c0,25.1,-18,46,-41.9,50.5L7.5,215.5l50,0L57.5,54.6L7.5,54.6z" id="cover" gorn="0.1.8"/>
         <circle stroke-width="0" cy="234.7" fill="#212121"  r="20.6" cx="65"/>
-        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">ULN2003A</text>
+        <text stroke-width="0" font-family="OCRA" fill="#e6e6e6"  stroke="none" text-anchor="start" id="label" x="65" y="165" gorn="0.1.10" font-size="80">4060</text>
         <rect stroke-width="0" width="30" fill="#8C8C8C"  height="43.4" id="connector0pin" x="35" y="286.6" gorn="0.1.11"/>
         <rect stroke-width="0" width="30" fill="#8C8C8C"  height="30" id="connector0terminal" x="35" y="300" gorn="0.1.12"/>
         <polygon stroke-width="0" fill="#8C8C8C"  points="35,286.6,35,306.6,65,306.6,85,297.4,85,286.6"/>

--- a/svg/contrib/pcb/4060_pcb.svg
+++ b/svg/contrib/pcb/4060_pcb.svg
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" width="0.42in" viewBox="0 0 420 820"  height="0.82in" version="1.2" baseProfile="tiny">
+    <desc >
+        <referenceFile >dip_16_300mil_pcb.svg</referenceFile>
+    </desc>
+    <desc >Fritzing footprint SVG</desc>
+    <g  id="silkscreen" gorn="0.2">
+        <line stroke-width="10" x1="10" x2="10"  stroke="white" y1="10" y2="810"/>
+        <line stroke-width="10" x1="10" x2="410"  stroke="white" y1="810" y2="810"/>
+        <line stroke-width="10" x1="410" x2="410"  stroke="white" y1="810" y2="10"/>
+        <line stroke-width="10" x1="10" x2="160"  stroke="white" y1="10" y2="10"/>
+        <line stroke-width="10" x1="260" x2="410"  stroke="white" y1="10" y2="10"/>
+    </g>
+    <g  id="copper1" gorn="0.3">
+        <g  id="copper0" gorn="0.3.0">
+            <rect stroke-width="20" width="55" fill="none"  stroke="rgb(255, 191, 0)" height="55" id="square" x="32.5" y="32.5" gorn="0.3.0.0"/>
+            <circle stroke-width="20" cy="60" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector0pin" gorn="0.3.0.1" cx="60"/>
+            <circle stroke-width="20" cy="60" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector15pin" gorn="0.3.0.2" cx="360"/>
+            <circle stroke-width="20" cy="160" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector1pin" gorn="0.3.0.3" cx="60"/>
+            <circle stroke-width="20" cy="160" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector14pin" gorn="0.3.0.4" cx="360"/>
+            <circle stroke-width="20" cy="260" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector2pin" gorn="0.3.0.5" cx="60"/>
+            <circle stroke-width="20" cy="260" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector13pin" gorn="0.3.0.6" cx="360"/>
+            <circle stroke-width="20" cy="360" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector3pin" gorn="0.3.0.7" cx="60"/>
+            <circle stroke-width="20" cy="360" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector12pin" gorn="0.3.0.8" cx="360"/>
+            <circle stroke-width="20" cy="460" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector4pin" gorn="0.3.0.9" cx="60"/>
+            <circle stroke-width="20" cy="460" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector11pin" gorn="0.3.0.10" cx="360"/>
+            <circle stroke-width="20" cy="560" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector5pin" gorn="0.3.0.11" cx="60"/>
+            <circle stroke-width="20" cy="560" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector10pin" gorn="0.3.0.12" cx="360"/>
+            <circle stroke-width="20" cy="660" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector6pin" gorn="0.3.0.13" cx="60"/>
+            <circle stroke-width="20" cy="660" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector9pin" gorn="0.3.0.14" cx="360"/>
+            <circle stroke-width="20" cy="760" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector7pin" gorn="0.3.0.15" cx="60"/>
+            <circle stroke-width="20" cy="760" fill="none"  r="27.5" stroke="rgb(255, 191, 0)" id="connector8pin" gorn="0.3.0.16" cx="360"/>
+        </g>
+    </g>
+</svg>

--- a/svg/contrib/schematic/4060_schematic.svg
+++ b/svg/contrib/schematic/4060_schematic.svg
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1.5in" viewBox="0 0 108 64.8"  height="0.9in" id="svg2" x="0in" version="1.2" y="0in" gorn="0">
+    <desc >
+        <referenceFile >4060.svg</referenceFile>
+    </desc>
+    <metadata  id="metadata110">
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <cc:Work rdf:about="" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#">
+                <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/svg+xml</dc:format>
+                <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+                <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+            </cc:Work>
+        </rdf:RDF>
+    </metadata>
+    <defs  id="defs108"/>
+    <rect stroke-width="0.89999998" width="78.300003" fill="#ffffff" class="interior rect"  stroke="#000000" height="63.900002" id="rect7" x="14.85" y="0.44999999" gorn="0.3" style="stroke-linecap:round"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector15pin" gorn="0.4" style="stroke-linecap:round" y1="7.1999998" y2="7.1999998"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text10" x="100.45" y="6.1499901" gorn="0.5" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">16</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text12" gorn="0.6" style="font-family:Droid Sans;text-anchor:end;-inkscape-font-specification:'Droid Sans, Normal';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;text-align:end;writing-mode:lr;line-height:125%;" font-size="2.8">
+        <text  id="tspan3595" x="91.849899" y="7.8999901" gorn="0.6.0">VDD</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector15terminal" x="107.65" y="6.85001" gorn="0.7"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector14pin" gorn="0.8" style="stroke-linecap:round" y1="14.4" y2="14.4"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text16" x="100.45" y="13.35" gorn="0.9" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">15</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text18" gorn="0.10" style="font-family:Droid Sans;text-anchor:end;-inkscape-font-specification:'Droid Sans, Normal';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;text-align:end;writing-mode:lr;line-height:125%;" font-size="2.8">
+        <text  id="tspan3597" x="91.849899" y="15.1" gorn="0.10.0">Q9</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector14terminal" x="107.65" y="14.05" gorn="0.11"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector13pin" gorn="0.12" style="stroke-linecap:round" y1="21.6" y2="21.6"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text22" x="100.45" y="20.549999" gorn="0.13" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">14</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text24" gorn="0.14" style="font-family:Droid Sans;text-anchor:end;-inkscape-font-specification:'Droid Sans, Normal';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;text-align:end;writing-mode:lr;line-height:125%;" font-size="2.8">
+        <text  id="tspan3599" x="91.849899" y="22.299999" gorn="0.14.0">Q7</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector13terminal" x="107.65" y="21.25" gorn="0.15"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector12pin" gorn="0.16" style="stroke-linecap:round" y1="28.799999" y2="28.799999"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text28" x="100.45" y="27.75" gorn="0.17" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">13</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text30" gorn="0.18" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:end;writing-mode:lr;text-anchor:end;" font-size="2.8">
+        <text  id="tspan3601" x="91.849899" y="29.499901" gorn="0.18.0">Q8</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector12terminal" x="107.65" y="28.4499" gorn="0.19"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector11pin" gorn="0.20" style="stroke-linecap:round" y1="36" y2="36"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text34" x="100.45" y="34.950001" gorn="0.21" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">12</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text36" gorn="0.22" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:end;writing-mode:lr;text-anchor:end;" font-size="2.8">
+        <text  id="tspan3603" x="91.849899" y="36.699902" gorn="0.22.0">MR</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector11terminal" x="107.65" y="35.6499" gorn="0.23"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector10pin" gorn="0.24" style="stroke-linecap:round" y1="43.200001" y2="43.200001"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text40" x="100.45" y="42.150002" gorn="0.25" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">11</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text42" gorn="0.26" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:end;writing-mode:lr;text-anchor:end;" font-size="2.8">
+        <text  id="tspan3605" x="91.849899" y="43.899899" gorn="0.26.0">RS</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector10terminal" x="107.65" y="42.8499" gorn="0.27"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector9pin" gorn="0.28" style="stroke-linecap:round" y1="50.400002" y2="50.400002"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text46" x="100.45" y="49.349998" gorn="0.29" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">10</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text48" gorn="0.30" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:end;writing-mode:lr;text-anchor:end;" font-size="2.8">
+        <text  id="tspan3607" x="91.849899" y="51.099899" gorn="0.30.0">REXT</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector9terminal" x="107.65" y="50.0499" gorn="0.31"/>
+    <line stroke-width="0.69999897" x1="93.249901" fill="none" x2="107.65" class="pin"  stroke="#787878" id="connector8pin" gorn="0.32" style="stroke-linecap:round" y1="57.599998" y2="57.599998"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text52" x="100.45" y="56.549999" gorn="0.33" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">9</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text54" gorn="0.34" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:end;writing-mode:lr;text-anchor:end;" font-size="2.8">
+        <text  id="tspan3609" x="91.849899" y="58.2999" gorn="0.34.0">CEXT</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector8terminal" x="107.65" y="57.2499" gorn="0.35"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector0pin" gorn="0.36" style="stroke-linecap:round" y1="7.1999998" y2="7.1999998"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text58" x="7.5499902" y="6.1499901" gorn="0.37" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">1</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text60" gorn="0.38" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3577" x="16.15" y="7.8999901" gorn="0.38.0">Q11</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector0terminal" x="-0.349999" y="6.85001" gorn="0.39"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector1pin" gorn="0.40" style="stroke-linecap:round" y1="14.4" y2="14.4"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text64" x="7.5499902" y="13.35" gorn="0.41" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">2</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text66" gorn="0.42" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3579" x="16.15" y="15.1" gorn="0.42.0">Q12</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector1terminal" x="-0.349999" y="14.05" gorn="0.43"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector2pin" gorn="0.44" style="stroke-linecap:round" y1="21.6" y2="21.6"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text70" x="7.5499902" y="20.549999" gorn="0.45" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">3</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text72" gorn="0.46" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3581" x="16.15" y="22.299999" gorn="0.46.0">Q13</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector2terminal" x="-0.349999" y="21.25" gorn="0.47"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector3pin" gorn="0.48" style="stroke-linecap:round" y1="28.799999" y2="28.799999"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text76" x="7.5499902" y="27.75" gorn="0.49" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">4</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text78" gorn="0.50" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3583" x="16.15" y="29.499901" gorn="0.50.0">Q5</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector3terminal" x="-0.349999" y="28.4499" gorn="0.51"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector4pin" gorn="0.52" style="stroke-linecap:round" y1="36" y2="36"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text82" x="7.5499902" y="34.950001" gorn="0.53" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">5</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text84" gorn="0.54" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3585" x="16.15" y="36.699902" gorn="0.54.0">Q4</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector4terminal" x="-0.349999" y="35.6499" gorn="0.55"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector5pin" gorn="0.56" style="stroke-linecap:round" y1="43.200001" y2="43.200001"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text88" x="7.5499902" y="42.150002" gorn="0.57" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">6</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text90" gorn="0.58" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3587" x="16.15" y="43.899899" gorn="0.58.0">Q6</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector5terminal" x="-0.349999" y="42.8499" gorn="0.59"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector6pin" gorn="0.60" style="stroke-linecap:round" y1="50.400002" y2="50.400002"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text94" x="7.5499902" y="49.349998" gorn="0.61" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">7</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text96" gorn="0.62" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3589" x="16.15" y="51.099899" gorn="0.62.0">Q3</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector6terminal" x="-0.349999" y="50.0499" gorn="0.63"/>
+    <line stroke-width="0.69999897" x1="0.34999901" fill="none" x2="14.75" class="pin"  stroke="#787878" id="connector7pin" gorn="0.64" style="stroke-linecap:round" y1="57.599998" y2="57.599998"/>
+    <text stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text100" x="7.5499902" y="56.549999" gorn="0.65" style="font-family:Droid Sans;text-anchor:middle;" font-size="2">8</text>
+    <g stroke-width="0" fill="#8c8c8c" class="text"  stroke="none" id="text102" gorn="0.66" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:start;writing-mode:lr;text-anchor:start;" font-size="2.8">
+        <text  id="tspan3591" x="16.15" y="58.2999" gorn="0.66.0">GND</text>
+    </g>
+    <g stroke-width="0" width="0.699999" fill="none" class="terminal"  stroke="none" height="0.699999" id="connector7terminal" x="-0.349999" y="57.2499" gorn="0.67"/>
+    <g stroke-width="0" fill="#000000" class="text"  stroke="none" id="label" gorn="0.68" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;font-family:Droid Sans;-inkscape-font-specification:'Droid Sans, Normal';text-align:center;writing-mode:lr;text-anchor:middle;" font-size="3.4">
+        <text  id="tspan3575" x="54.4501" y="30.5833" gorn="0.68.0">4060</text>
+    </g>
+</svg>


### PR DESCRIPTION
Hi - this is my first Fritzing part. 

It is a [4060 14-stage ripple-carry binary counter/divider and oscillator](http://www.nxp.com/documents/data_sheet/HEF4060B.pdf).

The [google code parts issue](https://code.google.com/p/fritzing/issues/detail?id=2753) is now read only so I figure this repo is how to contribute parts?

Notes
* I've read the contribution guidelines but it doesn't indicate whether I should putting parts in core or `contrib`. I chose `contrib`.
* To get the base line part, I copied from a `ULN2003A` which you can see references to in the source - does that need cleaning up?
* I assume the generic 4060 name is ok and it doesn't need to be more specific?
* The exported part had GUID's in the filenames when unzipped - which I cleaned up, I'm assuming I got the file names correct. Is there a way to compile the part again to ensure I got this correct?

any problems, let me know and I will correct
cheers!