### PR TITLE
add new custom part tilt switch sw-200d

### DIFF
--- a/core/SMD_LGA-12.fzp
+++ b/core/SMD_LGA-12.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_bma180_schematic.svg">
+<layers image="schematic/IC12.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-14.fzp
+++ b/core/SMD_LGA-14.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_adxl345_schematic.svg">
+<layers image="schematic/IC14.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-16-3mm.fzp
+++ b/core/SMD_LGA-16-3mm.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_lis331-1_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-16-4x4.fzp
+++ b/core/SMD_LGA-16-4x4.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_l3g4200d_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-28-4x5.fzp
+++ b/core/SMD_LGA-28-4x5.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_st-gyro-pr_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-28-5x5.fzp
+++ b/core/SMD_LGA-28-5x5.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_lsm303dlh_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-28.fzp
+++ b/core/SMD_LGA-28.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_lisy300al_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-281.fzp
+++ b/core/SMD_LGA-281.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_lypr540ah_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-44.fzp
+++ b/core/SMD_LGA-44.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-rf_venus634flpx_schematic.svg">
+<layers image="schematic/IC44.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LGA-8.fzp
+++ b/core/SMD_LGA-8.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_mpl115a_schematic.svg">
+<layers image="schematic/IC8.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_LQFP-64-10mm.fzp
+++ b/core/SMD_LQFP-64-10mm.fzp
@@ -26,7 +26,7 @@
    </layers>
   </breadboardView>
   <schematicView>
-   <layers image="schematic/Frode_3.svg">
+   <layers image="schematic/IC64.svg">
     <layer layerId="schematic"/>
    </layers>
   </schematicView>

--- a/core/SMD_LQFP-64.fzp
+++ b/core/SMD_LQFP-64.fzp
@@ -26,7 +26,7 @@
    </layers>
   </breadboardView>
   <schematicView>
-   <layers image="schematic/Frode_3.svg">
+   <layers image="schematic/IC64.svg">
     <layer layerId="schematic"/>
    </layers>
   </schematicView>

--- a/core/SMD_LQFP-80.fzp
+++ b/core/SMD_LQFP-80.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_w5100_schematic.svg">
+<layers image="schematic/IC80.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_MSOP10.fzp
+++ b/core/SMD_MSOP10.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_ltc3588_schematic.svg">
+<layers image="schematic/IC10.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_MSOP8.fzp
+++ b/core/SMD_MSOP8.fzp
@@ -24,7 +24,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-analogic_ltc6244_mix_7_schematic.svg">
+<layers image="schematic/IC8.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_PQFP-208.fzp
+++ b/core/SMD_PQFP-208.fzp
@@ -24,7 +24,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_ep2c20_pq208_pll_mix_9_schematic.svg">
+<layers image="schematic/IC208.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_PSOP8.fzp
+++ b/core/SMD_PSOP8.fzp
@@ -24,7 +24,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_pca9306_schematic.svg">
+<layers image="schematic/IC8.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-10-pad.fzp
+++ b/core/SMD_QFN-10-pad.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_tps61200_schematic.svg">
+<layers image="schematic/IC10.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-16-0.5mm.fzp
+++ b/core/SMD_QFN-16-0.5mm.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_mma8452q_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-16-4x4.fzp
+++ b/core/SMD_QFN-16-4x4.fzp
@@ -29,7 +29,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_tps6211__schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-16.fzp
+++ b/core/SMD_QFN-16.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_hdjd-s822-qr999_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-20.fzp
+++ b/core/SMD_QFN-20.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-rf_nrf24l01-1_schematic.svg">
+<layers image="schematic/IC20.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-28-5mm.fzp
+++ b/core/SMD_QFN-28-5mm.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_a4983_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-28-6x8.fzp
+++ b/core/SMD_QFN-28-6x8.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-sensors_isz-500_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-28-s.fzp
+++ b/core/SMD_QFN-28-s.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_stn1110-qfn_schematic.svg">
+<layers image="schematic/IC28.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-44-pad.fzp
+++ b/core/SMD_QFN-44-pad.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_atmega32u4_schematic.svg">
+<layers image="schematic/IC44.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN-44.fzp
+++ b/core/SMD_QFN-44.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_atmega32u4_schematic.svg">
+<layers image="schematic/IC44.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_QFN16-3mm.fzp
+++ b/core/SMD_QFN16-3mm.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_tps62143_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_SOP14.fzp
+++ b/core/SMD_SOP14.fzp
@@ -24,7 +24,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_ws2801_schematic.svg">
+<layers image="schematic/IC14.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_SQFP-64-10mm.fzp
+++ b/core/SMD_SQFP-64-10mm.fzp
@@ -24,7 +24,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_lpc213x_schematic.svg">
+<layers image="schematic/IC64.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_SSOP4.fzp
+++ b/core/SMD_SSOP4.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-discretesemi_tcmt1103_schematic.svg">
+<layers image="schematic/IC4.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-100-12mm.fzp
+++ b/core/SMD_TQFP-100-12mm.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_dspic33fj256gp710_power_mix_8_schematic.svg">
+<layers image="schematic/IC100.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-100-14mm.fzp
+++ b/core/SMD_TQFP-100-14mm.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/mega2560_schematic.svg">
+<layers image="schematic/IC100.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-32-8mm.fzp
+++ b/core/SMD_TQFP-32-8mm.fzp
@@ -30,7 +30,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_atmega328_schematic.svg">
+<layers image="schematic/IC32.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-44.fzp
+++ b/core/SMD_TQFP-44.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_dspic30f4011_schematic.svg">
+<layers image="schematic/IC44.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-64-10mm.fzp
+++ b/core/SMD_TQFP-64-10mm.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_atmega128_schematic.svg">
+<layers image="schematic/IC64.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TQFP-64-14mm.fzp
+++ b/core/SMD_TQFP-64-14mm.fzp
@@ -26,7 +26,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_atmega128_schematic.svg">
+<layers image="schematic/IC64.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TSOP48.fzp
+++ b/core/SMD_TSOP48.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_nand256_schematic.svg">
+<layers image="schematic/IC48.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TSSOP16.fzp
+++ b/core/SMD_TSSOP16.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-poweric_lm5574_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TSSOP30.fzp
+++ b/core/SMD_TSSOP30.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_stw5093_schematic.svg">
+<layers image="schematic/IC30.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TSSOP5.fzp
+++ b/core/SMD_TSSOP5.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-digitalic_inverting_schmitt_trigger_schematic.svg">
+<layers image="schematic/IC5.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/SMD_TVSOP16.fzp
+++ b/core/SMD_TVSOP16.fzp
@@ -25,7 +25,7 @@
 </layers>
 </breadboardView>
 <schematicView>
-<layers image="schematic/sparkfun-analogic_sn74lv4052apwr_schematic.svg">
+<layers image="schematic/IC16.svg">
 <layer layerId="schematic"/>
 </layers>
 </schematicView>

--- a/core/part.tilt-switch-sw200d_1b7c85bbf48b8a3270358749bb53b4c6_1.fzp
+++ b/core/part.tilt-switch-sw200d_1b7c85bbf48b8a3270358749bb53b4c6_1.fzp
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<module referenceFile="sparkfun-electromechanical-switch-momentary-2-pth_reed2.fzp" fritzingVersion="0.7.2b" moduleId="tilt-switch-sw200d_1b7c85bbf48b8a3270358749bb53b4c6_1">
+ <!-- generated from Sparkfun Eagle Library 'SparkFun-Electromechanical' SWITCH-MOMENTARY-2 PTH_REED2 -->
+ <version>4</version>
+ <date>Fri Apr 22 2016</date>
+ <label>S</label>
+ <author>Sayanee Basu, Leon Lim</author>
+ <description>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">Tilt switch SW-200D&lt;/p>&lt;/body>&lt;/html></description>
+ <title>TILT-SWITCH-SW-200D</title>
+ <tags>
+  <tag>sw-200d</tag>
+  <tag>tilt</tag>
+  <tag>switch</tag>
+ </tags>
+ <properties>
+  <property name="package">reed_switch_plastic</property>
+  <property name="part number"></property>
+  <property name="layer"></property>
+  <property name="variant">variant 1</property>
+  <property name="family">tilt switch</property>
+ </properties>
+ <views>
+  <breadboardView>
+   <layers image="breadboard/tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_breadboard.svg">
+    <layer layerId="breadboard"/>
+   </layers>
+  </breadboardView>
+  <schematicView>
+   <layers image="schematic/tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_schematic.svg">
+    <layer layerId="schematic"/>
+   </layers>
+  </schematicView>
+  <pcbView>
+   <layers image="pcb/tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_pcb.svg">
+    <layer layerId="copper1"/>
+    <layer layerId="silkscreen"/>
+    <layer layerId="copper0"/>
+   </layers>
+  </pcbView>
+  <iconView>
+   <layers image="icon/tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_icon.svg">
+    <layer layerId="icon"/>
+   </layers>
+  </iconView>
+ </views>
+ <connectors>
+  <connector type="male" id="connector0" name="1">
+   <description>1</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector0pin" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p terminalId="connector0terminal" svgId="connector0pin" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector0pad" layer="copper0"/>
+     <p svgId="connector0pad" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector type="male" id="connector1" name="2">
+   <description>2</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector1pin" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p terminalId="connector2terminal" svgId="connector2pin" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector1pad" layer="copper0"/>
+     <p svgId="connector1pad" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+ </connectors>
+ <buses/>
+</module>

--- a/svg/core/breadboard/svg.breadboard.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_breadboard.svg
+++ b/svg/core/breadboard/svg.breadboard.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_breadboard.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" width="0.63in" height="0.11in" xml:space="preserve"  version="1.1" xmlns:xml="http://www.w3.org/XML/1998/namespace" id="Layer_1" viewBox="0 0 45.002 8.004" gorn="0">
+    <desc  id="desc3">
+        <referenceFile  id="referenceFile5">reed_switch_leg.svg</referenceFile>
+    </desc>
+    <metadata  id="metadata162">
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <cc:Work rdf:about="" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/svg+xml</dc:format>
+                <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+                <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+            </cc:Work>
+        </rdf:RDF>
+    </metadata>
+    <defs  id="defs160"/>
+    <g  id="breadboard" gorn="0.3">
+        <rect width="1" x="0" y="2.937" height="1"  id="connector0pin" style="fill:none" gorn="0.3.0"/>
+        <rect width="1" x="40.641998" y="2.9360001" height="1"  id="connector1pin" style="fill:none" gorn="0.3.1"/>
+        <line fill="none"  id="connector0leg" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5;stroke-linecap:round" x1="0" stroke-width="2.5" x2="3" gorn="0.3.2" stroke="#6D6D6D" stroke-linecap="round"/>
+        <line fill="none"  id="connector1leg" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5;stroke-linecap:round" x1="45.001999" stroke-width="2.5" x2="42.001999" gorn="0.3.3" stroke="#6D6D6D" stroke-linecap="round"/>
+        <line fill="none"  id="line12" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5" x1="6.2319999" stroke-width="2.5" x2="3" gorn="0.3.4" stroke="#6D6D6D"/>
+        <line fill="none"  id="line14" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5" x1="42.001999" stroke-width="2.5" x2="39.016998" gorn="0.3.5" stroke="#6D6D6D"/>
+    </g>
+    <rect width="32.494068" x="9.3636141" y="-0.17192671" rx="1.5" ry="1.5" height="8.1759262"  id="rect3293" style="fill:#333333" gorn="0.4"/>
+    <rect width="32.494068" x="9.4432297" y="1.365427" height="5.2409787"  id="rect3283" style="fill:#1a1a1a" gorn="0.5"/>
+    <g transform="matrix(0.80848488,0,0,0.80848488,-0.41954665,0)" >
+        <g >
+            <g >
+                <rect width="3.8894815" x="8.2111282" y="3.503963" height="3.1115851"  id="rect3295" style="fill:#666666" gorn="0.6.0.0.0"/>
+            </g>
+        </g>
+    </g>
+    <g fill-opacity="1" font-size="5.13347" xml:space="preserve" fill="#ececec"  xmlns:xml="http://www.w3.org/XML/1998/namespace" id="text3297" style="font-style:normal;font-weight:normal;line-height:118.00000668%;letter-spacing:0px;word-spacing:0px;font-family:Droid Sans" gorn="0.7" stroke="none">
+        <text x="14.185314" y="5.837729"  id="tspan3299" style="font-size:4.85090923px;line-height:118.00000668%;letter-spacing:-0.03233939px;fill:#ececec" gorn="0.7.0">SW-200D</text>
+    </g>
+</svg>

--- a/svg/core/icon/svg.icon.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_icon.svg
+++ b/svg/core/icon/svg.icon.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_icon.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" width="0.63in" height="0.11in" xml:space="preserve"  version="1.1" xmlns:xml="http://www.w3.org/XML/1998/namespace" id="Layer_1" viewBox="0 0 45.002 8.004" gorn="0">
+    <desc  id="desc3">
+        <referenceFile  id="referenceFile5">reed_switch_leg.svg</referenceFile>
+    </desc>
+    <metadata  id="metadata162">
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+            <cc:Work rdf:about="" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/svg+xml</dc:format>
+                <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+                <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+            </cc:Work>
+        </rdf:RDF>
+    </metadata>
+    <defs  id="defs160"/>
+    <g  id="breadboard" gorn="0.3">
+        <rect width="1" x="0" y="2.937" height="1"  id="connector0pin" style="fill:none" gorn="0.3.0"/>
+        <rect width="1" x="40.641998" y="2.9360001" height="1"  id="connector1pin" style="fill:none" gorn="0.3.1"/>
+        <line fill="none"  id="connector0leg" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5;stroke-linecap:round" x1="0" stroke-width="2.5" x2="3" gorn="0.3.2" stroke="#6D6D6D" stroke-linecap="round"/>
+        <line fill="none"  id="connector1leg" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5;stroke-linecap:round" x1="45.001999" stroke-width="2.5" x2="42.001999" gorn="0.3.3" stroke="#6D6D6D" stroke-linecap="round"/>
+        <line fill="none"  id="line12" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5" x1="6.2319999" stroke-width="2.5" x2="3" gorn="0.3.4" stroke="#6D6D6D"/>
+        <line fill="none"  id="line14" y1="4.0619998" y2="4.0619998" style="fill:none;stroke:#6d6d6d;stroke-width:2.5" x1="42.001999" stroke-width="2.5" x2="39.016998" gorn="0.3.5" stroke="#6D6D6D"/>
+    </g>
+    <rect width="32.494068" x="9.3636141" y="-0.17192671" rx="1.5" ry="1.5" height="8.1759262"  id="rect3293" style="fill:#333333" gorn="0.4"/>
+    <rect width="32.494068" x="9.4432297" y="1.365427" height="5.2409787"  id="rect3283" style="fill:#1a1a1a" gorn="0.5"/>
+    <g transform="matrix(0.80848488,0,0,0.80848488,-0.41954665,0)" >
+        <g >
+            <g >
+                <rect width="3.8894815" x="8.2111282" y="3.503963" height="3.1115851"  id="rect3295" style="fill:#666666" gorn="0.6.0.0.0"/>
+            </g>
+        </g>
+    </g>
+    <g fill-opacity="1" font-size="5.13347" xml:space="preserve" fill="#ececec"  xmlns:xml="http://www.w3.org/XML/1998/namespace" id="text3297" style="font-style:normal;font-weight:normal;line-height:118.00000668%;letter-spacing:0px;word-spacing:0px;font-family:Droid Sans" gorn="0.7" stroke="none">
+        <text x="14.185314" y="5.837729"  id="tspan3299" style="font-size:4.85090923px;line-height:118.00000668%;letter-spacing:-0.03233939px;fill:#ececec" gorn="0.7.0">SW-200D</text>
+    </g>
+</svg>

--- a/svg/core/pcb/svg.pcb.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_pcb.svg
+++ b/svg/core/pcb/svg.pcb.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_pcb.svg
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" x="0in" width="0.774in" baseProfile="tiny" y="0in" height="0.134921in"  version="1.2" viewBox="0 0 19.6596 3.427">
+    <desc >
+        <referenceFile >sparkfun-electromechanical_reed_switch_plastic_pcb.svg</referenceFile>
+    </desc>
+    <g  id="copper1" gorn="0.1">
+        <circle fill="none"  id="connector0pad" r="0.7239" cx="0.9398" connectorname="P$1" cy="1.7135" stroke-width="0.4318" gorn="0.1.0" stroke="#F7BD13"/>
+        <circle fill="none"  id="connector1pad" r="0.7239" cx="18.7198" connectorname="P$2" cy="1.7135" stroke-width="0.4318" gorn="0.1.1" stroke="#F7BD13"/>
+        <g  id="copper0" gorn="0.1.2">
+            <circle fill="none"  id="connector0pad" r="0.7239" cx="0.9398" connectorname="P$1" cy="1.7135" stroke-width="0.4318" gorn="0.1.2.0" stroke="#F7BD13"/>
+            <circle fill="none"  id="connector1pad" r="0.7239" cx="18.7198" connectorname="P$2" cy="1.7135" stroke-width="0.4318" gorn="0.1.2.1" stroke="#F7BD13"/>
+        </g>
+    </g>
+    <g  id="silkscreen" gorn="0.2">
+        <line class="other"  y1="3.3635" y2="3.3635" x1="2.3298" stroke-width="0.127" x2="17.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="3.3635" y2="1.7135" x1="2.3298" stroke-width="0.127" x2="2.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="1.7135" y2="0.0635" x1="2.3298" stroke-width="0.127" x2="2.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="0.0635" y2="0.0635" x1="2.3298" stroke-width="0.127" x2="17.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="0.0635" y2="1.7135" x1="17.3298" stroke-width="0.127" x2="17.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="1.7135" y2="3.3635" x1="17.3298" stroke-width="0.127" x2="17.3298" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="1.7135" y2="1.7135" x1="2.3298" stroke-width="0.127" x2="2.1098" stroke="#f0f0f0" stroke-linecap="round"/>
+        <line class="other"  y1="1.7135" y2="1.7135" x1="17.3298" stroke-width="0.127" x2="17.5498" stroke="#f0f0f0" stroke-linecap="round"/>
+    </g>
+</svg>

--- a/svg/core/schematic/IC10.svg
+++ b/svg/core/schematic/IC10.svg
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='0.6in' viewBox='0 0 50.4 43.2' >
+<g partID='58680'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="42.3" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="18.1" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" x="36" width="14.4" y="6.85" connectorname="10" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" x="36" width="14.4" y="14.05" connectorname="9" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" x="36" width="14.4" y="21.25" connectorname="8" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" x="36" width="14.4" y="28.45" connectorname="7" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" x="36" width="14.4" y="35.65" connectorname="6" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC100.svg
+++ b/svg/core/schematic/IC100.svg
@@ -1,0 +1,508 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.8in' height='5.1in' viewBox='0 0 57.6 367.2' >
+<g partID='59840'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="366.3" fill="none" x="14.4" width="28.35" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="28.8" y="176.5" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" connectorName="33" x="0" width="14.4" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="0" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" connectorName="34" x="0" width="14.4" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="0" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" connectorName="35" x="0" width="14.4" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="0" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" connectorName="36" x="0" width="14.4" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="0" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" connectorName="37" x="0" width="14.4" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="0" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" connectorName="38" x="0" width="14.4" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="0" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" connectorName="39" x="0" width="14.4" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="0" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" connectorName="40" x="0" width="14.4" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="0" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" connectorName="41" x="0" width="14.4" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="0" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" connectorName="42" x="0" width="14.4" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="0" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" connectorName="43" x="0" width="14.4" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="0" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" connectorName="44" x="0" width="14.4" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="0" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" connectorName="45" x="0" width="14.4" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="0" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" connectorName="46" x="0" width="14.4" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="0" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" connectorName="47" x="0" width="14.4" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="0" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" connectorName="48" x="0" width="14.4" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="0" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" connectorName="49" x="0" width="14.4" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="0" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" connectorName="50" x="0" width="14.4" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="0" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector99pin" fill="none" x="43.2" width="14.4" y="6.85" connectorname="100" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector99terminal" fill="none" x="57.6" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label99" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector98pin" fill="none" x="43.2" width="14.4" y="14.05" connectorname="99" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector98terminal" fill="none" x="57.6" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label98" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector97pin" fill="none" x="43.2" width="14.4" y="21.25" connectorname="98" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector97terminal" fill="none" x="57.6" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label97" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector96pin" fill="none" x="43.2" width="14.4" y="28.45" connectorname="97" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector96terminal" fill="none" x="57.6" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label96" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector95pin" fill="none" x="43.2" width="14.4" y="35.65" connectorname="96" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector95terminal" fill="none" x="57.6" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label95" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector94pin" fill="none" x="43.2" width="14.4" y="42.85" connectorname="95" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector94terminal" fill="none" x="57.6" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label94" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector93pin" fill="none" x="43.2" width="14.4" y="50.05" connectorname="94" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector93terminal" fill="none" x="57.6" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label93" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector92pin" fill="none" x="43.2" width="14.4" y="57.25" connectorname="93" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector92terminal" fill="none" x="57.6" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label92" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector91pin" fill="none" x="43.2" width="14.4" y="64.45" connectorname="92" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector91terminal" fill="none" x="57.6" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label91" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector90pin" fill="none" x="43.2" width="14.4" y="71.65" connectorname="91" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector90terminal" fill="none" x="57.6" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label90" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector89pin" fill="none" x="43.2" width="14.4" y="78.8501" connectorname="90" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector89terminal" fill="none" x="57.6" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label89" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector88pin" fill="none" x="43.2" width="14.4" y="86.0501" connectorname="89" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector88terminal" fill="none" x="57.6" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label88" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector87pin" fill="none" x="43.2" width="14.4" y="93.2501" connectorname="88" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector87terminal" fill="none" x="57.6" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label87" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector86pin" fill="none" x="43.2" width="14.4" y="100.45" connectorname="87" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector86terminal" fill="none" x="57.6" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label86" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector85pin" fill="none" x="43.2" width="14.4" y="107.65" connectorname="86" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector85terminal" fill="none" x="57.6" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label85" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector84pin" fill="none" x="43.2" width="14.4" y="114.85" connectorname="85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector84terminal" fill="none" x="57.6" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label84" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector83pin" fill="none" x="43.2" width="14.4" y="122.05" connectorname="84" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector83terminal" fill="none" x="57.6" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label83" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector82pin" fill="none" x="43.2" width="14.4" y="129.25" connectorname="83" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector82terminal" fill="none" x="57.6" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label82" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector81pin" fill="none" x="43.2" width="14.4" y="136.45" connectorname="82" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector81terminal" fill="none" x="57.6" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label81" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector80pin" fill="none" x="43.2" width="14.4" y="143.65" connectorname="81" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector80terminal" fill="none" x="57.6" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label80" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector79pin" fill="none" x="43.2" width="14.4" y="150.85" connectorname="80" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector79terminal" fill="none" x="57.6" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label79" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector78pin" fill="none" x="43.2" width="14.4" y="158.05" connectorname="79" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector78terminal" fill="none" x="57.6" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label78" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector77pin" fill="none" x="43.2" width="14.4" y="165.25" connectorname="78" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector77terminal" fill="none" x="57.6" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label77" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector76pin" fill="none" x="43.2" width="14.4" y="172.45" connectorname="77" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector76terminal" fill="none" x="57.6" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label76" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector75pin" fill="none" x="43.2" width="14.4" y="179.65" connectorname="76" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector75terminal" fill="none" x="57.6" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label75" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector74pin" fill="none" x="43.2" width="14.4" y="186.85" connectorname="75" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector74terminal" fill="none" x="57.6" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label74" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector73pin" fill="none" x="43.2" width="14.4" y="194.05" connectorname="74" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector73terminal" fill="none" x="57.6" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label73" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector72pin" fill="none" x="43.2" width="14.4" y="201.25" connectorname="73" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector72terminal" fill="none" x="57.6" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label72" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector71pin" fill="none" x="43.2" width="14.4" y="208.45" connectorname="72" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector71terminal" fill="none" x="57.6" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label71" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector70pin" fill="none" x="43.2" width="14.4" y="215.65" connectorname="71" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector70terminal" fill="none" x="57.6" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label70" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector69pin" fill="none" x="43.2" width="14.4" y="222.85" connectorname="70" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector69terminal" fill="none" x="57.6" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label69" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector68pin" fill="none" x="43.2" width="14.4" y="230.05" connectorname="69" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector68terminal" fill="none" x="57.6" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label68" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector67pin" fill="none" x="43.2" width="14.4" y="237.25" connectorname="68" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector67terminal" fill="none" x="57.6" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label67" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector66pin" fill="none" x="43.2" width="14.4" y="244.45" connectorname="67" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector66terminal" fill="none" x="57.6" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label66" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector65pin" fill="none" x="43.2" width="14.4" y="251.65" connectorname="66" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector65terminal" fill="none" x="57.6" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label65" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector64pin" fill="none" x="43.2" width="14.4" y="258.85" connectorname="65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector64terminal" fill="none" x="57.6" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label64" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" x="43.2" width="14.4" y="266.05" connectorname="64" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="57.6" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" x="43.2" width="14.4" y="273.25" connectorname="63" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="57.6" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" x="43.2" width="14.4" y="280.45" connectorname="62" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="57.6" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" x="43.2" width="14.4" y="287.65" connectorname="61" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="57.6" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" x="43.2" width="14.4" y="294.85" connectorname="60" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="57.6" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" x="43.2" width="14.4" y="302.05" connectorname="59" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="57.6" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" x="43.2" width="14.4" y="309.25" connectorname="58" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="57.6" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" x="43.2" width="14.4" y="316.45" connectorname="57" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="57.6" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" x="43.2" width="14.4" y="323.65" connectorname="56" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="57.6" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" x="43.2" width="14.4" y="330.85" connectorname="55" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="57.6" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" x="43.2" width="14.4" y="338.05" connectorname="54" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="57.6" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" x="43.2" width="14.4" y="345.25" connectorname="53" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="57.6" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" x="43.2" width="14.4" y="352.45" connectorname="52" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="57.6" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" x="43.2" width="14.4" y="359.65" connectorname="51" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="57.6" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC12.svg
+++ b/svg/core/schematic/IC12.svg
@@ -1,0 +1,68 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='0.7in' viewBox='0 0 50.4 50.4' >
+<g partID='58760'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="49.5" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="18.1" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" x="36" width="14.4" y="6.85" connectorname="12" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" x="36" width="14.4" y="14.05" connectorname="11" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" x="36" width="14.4" y="21.25" connectorname="10" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" x="36" width="14.4" y="28.45" connectorname="9" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" x="36" width="14.4" y="35.65" connectorname="8" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" x="36" width="14.4" y="42.85" connectorname="7" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC128.svg
+++ b/svg/core/schematic/IC128.svg
@@ -1,0 +1,648 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.8in' height='6.5in' viewBox='0 0 57.6 468' >
+<g partID='59900'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="467.1" fill="none" x="14.4" width="28.35" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="28.8" y="226.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" connectorName="33" x="0" width="14.4" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="0" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" connectorName="34" x="0" width="14.4" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="0" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" connectorName="35" x="0" width="14.4" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="0" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" connectorName="36" x="0" width="14.4" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="0" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" connectorName="37" x="0" width="14.4" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="0" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" connectorName="38" x="0" width="14.4" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="0" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" connectorName="39" x="0" width="14.4" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="0" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" connectorName="40" x="0" width="14.4" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="0" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" connectorName="41" x="0" width="14.4" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="0" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" connectorName="42" x="0" width="14.4" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="0" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" connectorName="43" x="0" width="14.4" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="0" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" connectorName="44" x="0" width="14.4" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="0" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" connectorName="45" x="0" width="14.4" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="0" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" connectorName="46" x="0" width="14.4" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="0" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" connectorName="47" x="0" width="14.4" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="0" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" connectorName="48" x="0" width="14.4" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="0" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" connectorName="49" x="0" width="14.4" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="0" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" connectorName="50" x="0" width="14.4" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="0" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" connectorName="51" x="0" width="14.4" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="0" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" connectorName="52" x="0" width="14.4" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="0" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" connectorName="53" x="0" width="14.4" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="0" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" connectorName="54" x="0" width="14.4" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="0" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" connectorName="55" x="0" width="14.4" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="0" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" connectorName="56" x="0" width="14.4" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="0" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" connectorName="57" x="0" width="14.4" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="0" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" connectorName="58" x="0" width="14.4" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="0" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" connectorName="59" x="0" width="14.4" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="0" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" connectorName="60" x="0" width="14.4" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="0" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" connectorName="61" x="0" width="14.4" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="0" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" connectorName="62" x="0" width="14.4" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="0" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" connectorName="63" x="0" width="14.4" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="0" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" connectorName="64" x="0" width="14.4" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="0" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector127pin" fill="none" x="43.2" width="14.4" y="6.85" connectorname="128" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector127terminal" fill="none" x="57.6" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label127" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector126pin" fill="none" x="43.2" width="14.4" y="14.05" connectorname="127" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector126terminal" fill="none" x="57.6" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label126" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector125pin" fill="none" x="43.2" width="14.4" y="21.25" connectorname="126" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector125terminal" fill="none" x="57.6" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label125" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector124pin" fill="none" x="43.2" width="14.4" y="28.45" connectorname="125" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector124terminal" fill="none" x="57.6" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label124" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector123pin" fill="none" x="43.2" width="14.4" y="35.65" connectorname="124" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector123terminal" fill="none" x="57.6" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label123" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector122pin" fill="none" x="43.2" width="14.4" y="42.85" connectorname="123" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector122terminal" fill="none" x="57.6" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label122" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector121pin" fill="none" x="43.2" width="14.4" y="50.05" connectorname="122" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector121terminal" fill="none" x="57.6" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label121" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector120pin" fill="none" x="43.2" width="14.4" y="57.25" connectorname="121" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector120terminal" fill="none" x="57.6" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label120" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector119pin" fill="none" x="43.2" width="14.4" y="64.45" connectorname="120" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector119terminal" fill="none" x="57.6" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label119" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector118pin" fill="none" x="43.2" width="14.4" y="71.65" connectorname="119" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector118terminal" fill="none" x="57.6" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label118" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector117pin" fill="none" x="43.2" width="14.4" y="78.8501" connectorname="118" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector117terminal" fill="none" x="57.6" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label117" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector116pin" fill="none" x="43.2" width="14.4" y="86.0501" connectorname="117" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector116terminal" fill="none" x="57.6" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label116" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector115pin" fill="none" x="43.2" width="14.4" y="93.2501" connectorname="116" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector115terminal" fill="none" x="57.6" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label115" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector114pin" fill="none" x="43.2" width="14.4" y="100.45" connectorname="115" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector114terminal" fill="none" x="57.6" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label114" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector113pin" fill="none" x="43.2" width="14.4" y="107.65" connectorname="114" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector113terminal" fill="none" x="57.6" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label113" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector112pin" fill="none" x="43.2" width="14.4" y="114.85" connectorname="113" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector112terminal" fill="none" x="57.6" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label112" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector111pin" fill="none" x="43.2" width="14.4" y="122.05" connectorname="112" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector111terminal" fill="none" x="57.6" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label111" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector110pin" fill="none" x="43.2" width="14.4" y="129.25" connectorname="111" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector110terminal" fill="none" x="57.6" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label110" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector109pin" fill="none" x="43.2" width="14.4" y="136.45" connectorname="110" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector109terminal" fill="none" x="57.6" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label109" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector108pin" fill="none" x="43.2" width="14.4" y="143.65" connectorname="109" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector108terminal" fill="none" x="57.6" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label108" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector107pin" fill="none" x="43.2" width="14.4" y="150.85" connectorname="108" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector107terminal" fill="none" x="57.6" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label107" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector106pin" fill="none" x="43.2" width="14.4" y="158.05" connectorname="107" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector106terminal" fill="none" x="57.6" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label106" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector105pin" fill="none" x="43.2" width="14.4" y="165.25" connectorname="106" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector105terminal" fill="none" x="57.6" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label105" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector104pin" fill="none" x="43.2" width="14.4" y="172.45" connectorname="105" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector104terminal" fill="none" x="57.6" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label104" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector103pin" fill="none" x="43.2" width="14.4" y="179.65" connectorname="104" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector103terminal" fill="none" x="57.6" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label103" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector102pin" fill="none" x="43.2" width="14.4" y="186.85" connectorname="103" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector102terminal" fill="none" x="57.6" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label102" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector101pin" fill="none" x="43.2" width="14.4" y="194.05" connectorname="102" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector101terminal" fill="none" x="57.6" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label101" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector100pin" fill="none" x="43.2" width="14.4" y="201.25" connectorname="101" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector100terminal" fill="none" x="57.6" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label100" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector99pin" fill="none" x="43.2" width="14.4" y="208.45" connectorname="100" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector99terminal" fill="none" x="57.6" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label99" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector98pin" fill="none" x="43.2" width="14.4" y="215.65" connectorname="99" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector98terminal" fill="none" x="57.6" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label98" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector97pin" fill="none" x="43.2" width="14.4" y="222.85" connectorname="98" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector97terminal" fill="none" x="57.6" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label97" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector96pin" fill="none" x="43.2" width="14.4" y="230.05" connectorname="97" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector96terminal" fill="none" x="57.6" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label96" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector95pin" fill="none" x="43.2" width="14.4" y="237.25" connectorname="96" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector95terminal" fill="none" x="57.6" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label95" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector94pin" fill="none" x="43.2" width="14.4" y="244.45" connectorname="95" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector94terminal" fill="none" x="57.6" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label94" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector93pin" fill="none" x="43.2" width="14.4" y="251.65" connectorname="94" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector93terminal" fill="none" x="57.6" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label93" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector92pin" fill="none" x="43.2" width="14.4" y="258.85" connectorname="93" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector92terminal" fill="none" x="57.6" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label92" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector91pin" fill="none" x="43.2" width="14.4" y="266.05" connectorname="92" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector91terminal" fill="none" x="57.6" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label91" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector90pin" fill="none" x="43.2" width="14.4" y="273.25" connectorname="91" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector90terminal" fill="none" x="57.6" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label90" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector89pin" fill="none" x="43.2" width="14.4" y="280.45" connectorname="90" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector89terminal" fill="none" x="57.6" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label89" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector88pin" fill="none" x="43.2" width="14.4" y="287.65" connectorname="89" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector88terminal" fill="none" x="57.6" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label88" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector87pin" fill="none" x="43.2" width="14.4" y="294.85" connectorname="88" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector87terminal" fill="none" x="57.6" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label87" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector86pin" fill="none" x="43.2" width="14.4" y="302.05" connectorname="87" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector86terminal" fill="none" x="57.6" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label86" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector85pin" fill="none" x="43.2" width="14.4" y="309.25" connectorname="86" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector85terminal" fill="none" x="57.6" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label85" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector84pin" fill="none" x="43.2" width="14.4" y="316.45" connectorname="85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector84terminal" fill="none" x="57.6" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label84" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector83pin" fill="none" x="43.2" width="14.4" y="323.65" connectorname="84" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector83terminal" fill="none" x="57.6" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label83" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector82pin" fill="none" x="43.2" width="14.4" y="330.85" connectorname="83" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector82terminal" fill="none" x="57.6" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label82" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector81pin" fill="none" x="43.2" width="14.4" y="338.05" connectorname="82" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector81terminal" fill="none" x="57.6" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label81" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector80pin" fill="none" x="43.2" width="14.4" y="345.25" connectorname="81" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector80terminal" fill="none" x="57.6" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label80" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector79pin" fill="none" x="43.2" width="14.4" y="352.45" connectorname="80" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector79terminal" fill="none" x="57.6" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label79" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector78pin" fill="none" x="43.2" width="14.4" y="359.65" connectorname="79" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector78terminal" fill="none" x="57.6" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label78" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector77pin" fill="none" x="43.2" width="14.4" y="366.85" connectorname="78" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector77terminal" fill="none" x="57.6" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label77" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector76pin" fill="none" x="43.2" width="14.4" y="374.05" connectorname="77" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector76terminal" fill="none" x="57.6" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label76" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector75pin" fill="none" x="43.2" width="14.4" y="381.25" connectorname="76" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector75terminal" fill="none" x="57.6" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label75" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector74pin" fill="none" x="43.2" width="14.4" y="388.45" connectorname="75" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector74terminal" fill="none" x="57.6" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label74" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector73pin" fill="none" x="43.2" width="14.4" y="395.65" connectorname="74" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector73terminal" fill="none" x="57.6" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label73" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector72pin" fill="none" x="43.2" width="14.4" y="402.85" connectorname="73" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector72terminal" fill="none" x="57.6" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label72" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector71pin" fill="none" x="43.2" width="14.4" y="410.05" connectorname="72" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector71terminal" fill="none" x="57.6" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label71" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector70pin" fill="none" x="43.2" width="14.4" y="417.25" connectorname="71" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector70terminal" fill="none" x="57.6" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label70" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector69pin" fill="none" x="43.2" width="14.4" y="424.45" connectorname="70" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector69terminal" fill="none" x="57.6" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label69" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector68pin" fill="none" x="43.2" width="14.4" y="431.65" connectorname="69" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector68terminal" fill="none" x="57.6" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label68" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector67pin" fill="none" x="43.2" width="14.4" y="438.85" connectorname="68" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector67terminal" fill="none" x="57.6" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label67" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector66pin" fill="none" x="43.2" width="14.4" y="446.05" connectorname="67" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector66terminal" fill="none" x="57.6" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label66" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector65pin" fill="none" x="43.2" width="14.4" y="453.25" connectorname="66" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector65terminal" fill="none" x="57.6" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label65" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector64pin" fill="none" x="43.2" width="14.4" y="460.45" connectorname="65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector64terminal" fill="none" x="57.6" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label64" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC14.svg
+++ b/svg/core/schematic/IC14.svg
@@ -1,0 +1,78 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='0.8in' viewBox='0 0 50.4 57.6' >
+<g partID='58820'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="56.7" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="25.3" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" x="36" width="14.4" y="6.85" connectorname="14" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" x="36" width="14.4" y="14.05" connectorname="13" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" x="36" width="14.4" y="21.25" connectorname="12" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" x="36" width="14.4" y="28.45" connectorname="11" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" x="36" width="14.4" y="35.65" connectorname="10" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" x="36" width="14.4" y="42.85" connectorname="9" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" x="36" width="14.4" y="50.05" connectorname="8" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC16.svg
+++ b/svg/core/schematic/IC16.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='0.9in' viewBox='0 0 50.4 64.8' >
+<g partID='59080'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="63.9" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="25.3" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="6.85" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" x="36" width="14.4" y="14.05" connectorname="15" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" x="36" width="14.4" y="21.25" connectorname="14" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" x="36" width="14.4" y="28.45" connectorname="13" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" x="36" width="14.4" y="35.65" connectorname="12" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" x="36" width="14.4" y="42.85" connectorname="11" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" x="36" width="14.4" y="50.05" connectorname="10" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" x="36" width="14.4" y="57.25" connectorname="9" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC18.svg
+++ b/svg/core/schematic/IC18.svg
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1in' viewBox='0 0 50.4 72' >
+<g partID='58940'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="71.1" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="32.5" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="6.85" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="14.05" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="21.25" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" x="36" width="14.4" y="28.45" connectorname="15" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" x="36" width="14.4" y="35.65" connectorname="14" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" x="36" width="14.4" y="42.85" connectorname="13" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" x="36" width="14.4" y="50.05" connectorname="12" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" x="36" width="14.4" y="57.25" connectorname="11" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" x="36" width="14.4" y="64.45" connectorname="10" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC20.svg
+++ b/svg/core/schematic/IC20.svg
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.1in' viewBox='0 0 50.4 79.2' >
+<g partID='59000'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="78.3" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="32.5" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="6.85" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="14.05" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="21.25" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="28.45" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="35.65" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" x="36" width="14.4" y="42.85" connectorname="15" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" x="36" width="14.4" y="50.05" connectorname="14" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" x="36" width="14.4" y="57.25" connectorname="13" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" x="36" width="14.4" y="64.45" connectorname="12" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" x="36" width="14.4" y="71.65" connectorname="11" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC208.svg
+++ b/svg/core/schematic/IC208.svg
@@ -1,0 +1,1048 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.8in' height='10.5in' viewBox='0 0 57.6 756' >
+<g partID='60000'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="755.1" fill="none" x="14.4" width="28.35" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="28.8" y="370.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" connectorName="33" x="0" width="14.4" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="0" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" connectorName="34" x="0" width="14.4" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="0" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" connectorName="35" x="0" width="14.4" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="0" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" connectorName="36" x="0" width="14.4" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="0" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" connectorName="37" x="0" width="14.4" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="0" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" connectorName="38" x="0" width="14.4" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="0" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" connectorName="39" x="0" width="14.4" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="0" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" connectorName="40" x="0" width="14.4" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="0" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" connectorName="41" x="0" width="14.4" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="0" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" connectorName="42" x="0" width="14.4" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="0" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" connectorName="43" x="0" width="14.4" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="0" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" connectorName="44" x="0" width="14.4" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="0" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" connectorName="45" x="0" width="14.4" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="0" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" connectorName="46" x="0" width="14.4" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="0" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" connectorName="47" x="0" width="14.4" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="0" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" connectorName="48" x="0" width="14.4" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="0" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" connectorName="49" x="0" width="14.4" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="0" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" connectorName="50" x="0" width="14.4" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="0" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" connectorName="51" x="0" width="14.4" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="0" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" connectorName="52" x="0" width="14.4" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="0" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" connectorName="53" x="0" width="14.4" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="0" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" connectorName="54" x="0" width="14.4" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="0" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" connectorName="55" x="0" width="14.4" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="0" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" connectorName="56" x="0" width="14.4" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="0" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" connectorName="57" x="0" width="14.4" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="0" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" connectorName="58" x="0" width="14.4" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="0" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" connectorName="59" x="0" width="14.4" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="0" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" connectorName="60" x="0" width="14.4" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="0" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" connectorName="61" x="0" width="14.4" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="0" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" connectorName="62" x="0" width="14.4" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="0" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" connectorName="63" x="0" width="14.4" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="0" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" connectorName="64" x="0" width="14.4" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="0" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="468" y2="468" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector64pin" fill="none" connectorName="65" x="0" width="14.4" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector64terminal" fill="none" x="0" width="0" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label64" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="468.7" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="466.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<line fill="none" y1="475.2" y2="475.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector65pin" fill="none" connectorName="66" x="0" width="14.4" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector65terminal" fill="none" x="0" width="0" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label65" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="475.9" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="474.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<line fill="none" y1="482.4" y2="482.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector66pin" fill="none" connectorName="67" x="0" width="14.4" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector66terminal" fill="none" x="0" width="0" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label66" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="483.1" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="481.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<line fill="none" y1="489.6" y2="489.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector67pin" fill="none" connectorName="68" x="0" width="14.4" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector67terminal" fill="none" x="0" width="0" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label67" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="490.3" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="488.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<line fill="none" y1="496.8" y2="496.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector68pin" fill="none" connectorName="69" x="0" width="14.4" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector68terminal" fill="none" x="0" width="0" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label68" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="497.5" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="495.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<line fill="none" y1="504" y2="504" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector69pin" fill="none" connectorName="70" x="0" width="14.4" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector69terminal" fill="none" x="0" width="0" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label69" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="504.7" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="502.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<line fill="none" y1="511.2" y2="511.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector70pin" fill="none" connectorName="71" x="0" width="14.4" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector70terminal" fill="none" x="0" width="0" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label70" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="511.9" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="510.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<line fill="none" y1="518.4" y2="518.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector71pin" fill="none" connectorName="72" x="0" width="14.4" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector71terminal" fill="none" x="0" width="0" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label71" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="519.1" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="517.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<line fill="none" y1="525.6" y2="525.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector72pin" fill="none" connectorName="73" x="0" width="14.4" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector72terminal" fill="none" x="0" width="0" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label72" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="526.3" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="524.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<line fill="none" y1="532.8" y2="532.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector73pin" fill="none" connectorName="74" x="0" width="14.4" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector73terminal" fill="none" x="0" width="0" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label73" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="533.5" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="531.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<line fill="none" y1="540" y2="540" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector74pin" fill="none" connectorName="75" x="0" width="14.4" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector74terminal" fill="none" x="0" width="0" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label74" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="540.7" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="538.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<line fill="none" y1="547.2" y2="547.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector75pin" fill="none" connectorName="76" x="0" width="14.4" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector75terminal" fill="none" x="0" width="0" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label75" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="547.9" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="546.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<line fill="none" y1="554.4" y2="554.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector76pin" fill="none" connectorName="77" x="0" width="14.4" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector76terminal" fill="none" x="0" width="0" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label76" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="555.1" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="553.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<line fill="none" y1="561.6" y2="561.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector77pin" fill="none" connectorName="78" x="0" width="14.4" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector77terminal" fill="none" x="0" width="0" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label77" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="562.3" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="560.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<line fill="none" y1="568.8" y2="568.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector78pin" fill="none" connectorName="79" x="0" width="14.4" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector78terminal" fill="none" x="0" width="0" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label78" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="569.5" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="567.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<line fill="none" y1="576" y2="576" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector79pin" fill="none" connectorName="80" x="0" width="14.4" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector79terminal" fill="none" x="0" width="0" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label79" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="576.7" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="574.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<line fill="none" y1="583.2" y2="583.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector80pin" fill="none" connectorName="81" x="0" width="14.4" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector80terminal" fill="none" x="0" width="0" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label80" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="583.9" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="582.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<line fill="none" y1="590.4" y2="590.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector81pin" fill="none" connectorName="82" x="0" width="14.4" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector81terminal" fill="none" x="0" width="0" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label81" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="591.1" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="589.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<line fill="none" y1="597.6" y2="597.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector82pin" fill="none" connectorName="83" x="0" width="14.4" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector82terminal" fill="none" x="0" width="0" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label82" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="598.3" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="596.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<line fill="none" y1="604.8" y2="604.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector83pin" fill="none" connectorName="84" x="0" width="14.4" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector83terminal" fill="none" x="0" width="0" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label83" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="605.5" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="603.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<line fill="none" y1="612" y2="612" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector84pin" fill="none" connectorName="85" x="0" width="14.4" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector84terminal" fill="none" x="0" width="0" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label84" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="612.7" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="610.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<line fill="none" y1="619.2" y2="619.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector85pin" fill="none" connectorName="86" x="0" width="14.4" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector85terminal" fill="none" x="0" width="0" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label85" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="619.9" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="618.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<line fill="none" y1="626.4" y2="626.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector86pin" fill="none" connectorName="87" x="0" width="14.4" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector86terminal" fill="none" x="0" width="0" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label86" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="627.1" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="625.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<line fill="none" y1="633.6" y2="633.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector87pin" fill="none" connectorName="88" x="0" width="14.4" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector87terminal" fill="none" x="0" width="0" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label87" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="634.3" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="632.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<line fill="none" y1="640.8" y2="640.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector88pin" fill="none" connectorName="89" x="0" width="14.4" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector88terminal" fill="none" x="0" width="0" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label88" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="641.5" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="639.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<line fill="none" y1="648" y2="648" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector89pin" fill="none" connectorName="90" x="0" width="14.4" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector89terminal" fill="none" x="0" width="0" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label89" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="648.7" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="646.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<line fill="none" y1="655.2" y2="655.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector90pin" fill="none" connectorName="91" x="0" width="14.4" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector90terminal" fill="none" x="0" width="0" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label90" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="655.9" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="654.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<line fill="none" y1="662.4" y2="662.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector91pin" fill="none" connectorName="92" x="0" width="14.4" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector91terminal" fill="none" x="0" width="0" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label91" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="663.1" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="661.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<line fill="none" y1="669.6" y2="669.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector92pin" fill="none" connectorName="93" x="0" width="14.4" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector92terminal" fill="none" x="0" width="0" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label92" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="670.3" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="668.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<line fill="none" y1="676.8" y2="676.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector93pin" fill="none" connectorName="94" x="0" width="14.4" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector93terminal" fill="none" x="0" width="0" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label93" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="677.5" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="675.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<line fill="none" y1="684" y2="684" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector94pin" fill="none" connectorName="95" x="0" width="14.4" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector94terminal" fill="none" x="0" width="0" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label94" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="684.7" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="682.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<line fill="none" y1="691.2" y2="691.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector95pin" fill="none" connectorName="96" x="0" width="14.4" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector95terminal" fill="none" x="0" width="0" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label95" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="691.9" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="690.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<line fill="none" y1="698.4" y2="698.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector96pin" fill="none" connectorName="97" x="0" width="14.4" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector96terminal" fill="none" x="0" width="0" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label96" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="699.1" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="697.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<line fill="none" y1="705.6" y2="705.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector97pin" fill="none" connectorName="98" x="0" width="14.4" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector97terminal" fill="none" x="0" width="0" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label97" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="706.3" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="704.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<line fill="none" y1="712.8" y2="712.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector98pin" fill="none" connectorName="99" x="0" width="14.4" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector98terminal" fill="none" x="0" width="0" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label98" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="713.5" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="711.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<line fill="none" y1="720" y2="720" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector99pin" fill="none" connectorName="100" x="0" width="14.4" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector99terminal" fill="none" x="0" width="0" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label99" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="720.698" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="718.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<line fill="none" y1="727.2" y2="727.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector100pin" fill="none" connectorName="101" x="0" width="14.4" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector100terminal" fill="none" x="0" width="0" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label100" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="727.898" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="726.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<line fill="none" y1="734.4" y2="734.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector101pin" fill="none" connectorName="102" x="0" width="14.4" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector101terminal" fill="none" x="0" width="0" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label101" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="735.098" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="733.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<line fill="none" y1="741.6" y2="741.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector102pin" fill="none" connectorName="103" x="0" width="14.4" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector102terminal" fill="none" x="0" width="0" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label102" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="742.298" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="740.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<line fill="none" y1="748.8" y2="748.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector103pin" fill="none" connectorName="104" x="0" width="14.4" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector103terminal" fill="none" x="0" width="0" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label103" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="749.498" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="747.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector207pin" fill="none" x="43.2" width="14.4" y="6.85" connectorname="208" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector207terminal" fill="none" x="57.6" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label207" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">208</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">208</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector206pin" fill="none" x="43.2" width="14.4" y="14.05" connectorname="207" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector206terminal" fill="none" x="57.6" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label206" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">207</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">207</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector205pin" fill="none" x="43.2" width="14.4" y="21.25" connectorname="206" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector205terminal" fill="none" x="57.6" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label205" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">206</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">206</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector204pin" fill="none" x="43.2" width="14.4" y="28.45" connectorname="205" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector204terminal" fill="none" x="57.6" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label204" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">205</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">205</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector203pin" fill="none" x="43.2" width="14.4" y="35.65" connectorname="204" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector203terminal" fill="none" x="57.6" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label203" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">204</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">204</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector202pin" fill="none" x="43.2" width="14.4" y="42.85" connectorname="203" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector202terminal" fill="none" x="57.6" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label202" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">203</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">203</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector201pin" fill="none" x="43.2" width="14.4" y="50.05" connectorname="202" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector201terminal" fill="none" x="57.6" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label201" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">202</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">202</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector200pin" fill="none" x="43.2" width="14.4" y="57.25" connectorname="201" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector200terminal" fill="none" x="57.6" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label200" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">201</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">201</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector199pin" fill="none" x="43.2" width="14.4" y="64.45" connectorname="200" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector199terminal" fill="none" x="57.6" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label199" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">200</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">200</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector198pin" fill="none" x="43.2" width="14.4" y="71.65" connectorname="199" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector198terminal" fill="none" x="57.6" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label198" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">199</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">199</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector197pin" fill="none" x="43.2" width="14.4" y="78.8501" connectorname="198" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector197terminal" fill="none" x="57.6" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label197" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">198</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">198</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector196pin" fill="none" x="43.2" width="14.4" y="86.0501" connectorname="197" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector196terminal" fill="none" x="57.6" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label196" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">197</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">197</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector195pin" fill="none" x="43.2" width="14.4" y="93.2501" connectorname="196" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector195terminal" fill="none" x="57.6" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label195" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">196</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">196</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector194pin" fill="none" x="43.2" width="14.4" y="100.45" connectorname="195" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector194terminal" fill="none" x="57.6" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label194" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">195</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">195</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector193pin" fill="none" x="43.2" width="14.4" y="107.65" connectorname="194" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector193terminal" fill="none" x="57.6" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label193" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">194</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">194</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector192pin" fill="none" x="43.2" width="14.4" y="114.85" connectorname="193" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector192terminal" fill="none" x="57.6" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label192" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">193</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">193</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector191pin" fill="none" x="43.2" width="14.4" y="122.05" connectorname="192" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector191terminal" fill="none" x="57.6" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label191" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">192</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">192</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector190pin" fill="none" x="43.2" width="14.4" y="129.25" connectorname="191" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector190terminal" fill="none" x="57.6" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label190" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">191</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">191</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector189pin" fill="none" x="43.2" width="14.4" y="136.45" connectorname="190" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector189terminal" fill="none" x="57.6" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label189" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">190</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">190</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector188pin" fill="none" x="43.2" width="14.4" y="143.65" connectorname="189" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector188terminal" fill="none" x="57.6" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label188" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">189</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">189</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector187pin" fill="none" x="43.2" width="14.4" y="150.85" connectorname="188" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector187terminal" fill="none" x="57.6" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label187" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">188</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">188</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector186pin" fill="none" x="43.2" width="14.4" y="158.05" connectorname="187" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector186terminal" fill="none" x="57.6" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label186" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">187</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">187</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector185pin" fill="none" x="43.2" width="14.4" y="165.25" connectorname="186" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector185terminal" fill="none" x="57.6" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label185" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">186</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">186</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector184pin" fill="none" x="43.2" width="14.4" y="172.45" connectorname="185" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector184terminal" fill="none" x="57.6" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label184" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">185</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">185</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector183pin" fill="none" x="43.2" width="14.4" y="179.65" connectorname="184" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector183terminal" fill="none" x="57.6" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label183" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">184</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">184</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector182pin" fill="none" x="43.2" width="14.4" y="186.85" connectorname="183" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector182terminal" fill="none" x="57.6" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label182" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">183</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">183</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector181pin" fill="none" x="43.2" width="14.4" y="194.05" connectorname="182" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector181terminal" fill="none" x="57.6" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label181" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">182</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">182</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector180pin" fill="none" x="43.2" width="14.4" y="201.25" connectorname="181" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector180terminal" fill="none" x="57.6" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label180" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">181</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">181</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector179pin" fill="none" x="43.2" width="14.4" y="208.45" connectorname="180" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector179terminal" fill="none" x="57.6" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label179" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">180</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">180</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector178pin" fill="none" x="43.2" width="14.4" y="215.65" connectorname="179" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector178terminal" fill="none" x="57.6" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label178" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">179</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">179</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector177pin" fill="none" x="43.2" width="14.4" y="222.85" connectorname="178" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector177terminal" fill="none" x="57.6" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label177" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">178</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">178</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector176pin" fill="none" x="43.2" width="14.4" y="230.05" connectorname="177" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector176terminal" fill="none" x="57.6" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label176" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">177</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">177</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector175pin" fill="none" x="43.2" width="14.4" y="237.25" connectorname="176" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector175terminal" fill="none" x="57.6" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label175" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">176</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">176</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector174pin" fill="none" x="43.2" width="14.4" y="244.45" connectorname="175" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector174terminal" fill="none" x="57.6" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label174" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">175</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">175</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector173pin" fill="none" x="43.2" width="14.4" y="251.65" connectorname="174" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector173terminal" fill="none" x="57.6" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label173" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">174</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">174</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector172pin" fill="none" x="43.2" width="14.4" y="258.85" connectorname="173" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector172terminal" fill="none" x="57.6" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label172" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">173</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">173</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector171pin" fill="none" x="43.2" width="14.4" y="266.05" connectorname="172" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector171terminal" fill="none" x="57.6" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label171" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">172</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">172</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector170pin" fill="none" x="43.2" width="14.4" y="273.25" connectorname="171" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector170terminal" fill="none" x="57.6" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label170" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">171</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">171</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector169pin" fill="none" x="43.2" width="14.4" y="280.45" connectorname="170" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector169terminal" fill="none" x="57.6" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label169" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">170</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">170</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector168pin" fill="none" x="43.2" width="14.4" y="287.65" connectorname="169" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector168terminal" fill="none" x="57.6" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label168" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">169</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">169</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector167pin" fill="none" x="43.2" width="14.4" y="294.85" connectorname="168" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector167terminal" fill="none" x="57.6" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label167" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">168</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">168</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector166pin" fill="none" x="43.2" width="14.4" y="302.05" connectorname="167" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector166terminal" fill="none" x="57.6" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label166" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">167</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">167</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector165pin" fill="none" x="43.2" width="14.4" y="309.25" connectorname="166" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector165terminal" fill="none" x="57.6" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label165" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">166</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">166</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector164pin" fill="none" x="43.2" width="14.4" y="316.45" connectorname="165" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector164terminal" fill="none" x="57.6" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label164" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">165</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">165</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector163pin" fill="none" x="43.2" width="14.4" y="323.65" connectorname="164" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector163terminal" fill="none" x="57.6" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label163" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">164</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">164</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector162pin" fill="none" x="43.2" width="14.4" y="330.85" connectorname="163" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector162terminal" fill="none" x="57.6" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label162" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">163</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">163</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector161pin" fill="none" x="43.2" width="14.4" y="338.05" connectorname="162" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector161terminal" fill="none" x="57.6" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label161" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">162</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">162</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector160pin" fill="none" x="43.2" width="14.4" y="345.25" connectorname="161" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector160terminal" fill="none" x="57.6" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label160" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">161</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">161</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector159pin" fill="none" x="43.2" width="14.4" y="352.45" connectorname="160" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector159terminal" fill="none" x="57.6" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label159" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">160</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">160</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector158pin" fill="none" x="43.2" width="14.4" y="359.65" connectorname="159" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector158terminal" fill="none" x="57.6" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label158" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">159</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">159</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector157pin" fill="none" x="43.2" width="14.4" y="366.85" connectorname="158" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector157terminal" fill="none" x="57.6" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label157" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">158</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">158</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector156pin" fill="none" x="43.2" width="14.4" y="374.05" connectorname="157" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector156terminal" fill="none" x="57.6" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label156" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">157</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">157</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector155pin" fill="none" x="43.2" width="14.4" y="381.25" connectorname="156" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector155terminal" fill="none" x="57.6" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label155" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">156</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">156</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector154pin" fill="none" x="43.2" width="14.4" y="388.45" connectorname="155" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector154terminal" fill="none" x="57.6" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label154" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">155</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">155</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector153pin" fill="none" x="43.2" width="14.4" y="395.65" connectorname="154" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector153terminal" fill="none" x="57.6" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label153" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">154</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">154</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector152pin" fill="none" x="43.2" width="14.4" y="402.85" connectorname="153" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector152terminal" fill="none" x="57.6" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label152" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">153</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">153</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector151pin" fill="none" x="43.2" width="14.4" y="410.05" connectorname="152" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector151terminal" fill="none" x="57.6" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label151" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">152</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">152</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector150pin" fill="none" x="43.2" width="14.4" y="417.25" connectorname="151" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector150terminal" fill="none" x="57.6" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label150" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">151</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">151</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector149pin" fill="none" x="43.2" width="14.4" y="424.45" connectorname="150" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector149terminal" fill="none" x="57.6" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label149" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">150</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">150</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector148pin" fill="none" x="43.2" width="14.4" y="431.65" connectorname="149" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector148terminal" fill="none" x="57.6" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label148" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">149</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">149</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector147pin" fill="none" x="43.2" width="14.4" y="438.85" connectorname="148" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector147terminal" fill="none" x="57.6" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label147" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">148</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">148</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector146pin" fill="none" x="43.2" width="14.4" y="446.05" connectorname="147" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector146terminal" fill="none" x="57.6" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label146" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">147</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">147</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector145pin" fill="none" x="43.2" width="14.4" y="453.25" connectorname="146" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector145terminal" fill="none" x="57.6" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label145" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">146</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">146</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector144pin" fill="none" x="43.2" width="14.4" y="460.45" connectorname="145" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector144terminal" fill="none" x="57.6" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label144" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">145</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">145</text>
+<line fill="none" y1="468" y2="468" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector143pin" fill="none" x="43.2" width="14.4" y="467.65" connectorname="144" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector143terminal" fill="none" x="57.6" width="0" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label143" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="468.7" stroke="none" xmlns="http://www.w3.org/2000/svg">144</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="466.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">144</text>
+<line fill="none" y1="475.2" y2="475.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector142pin" fill="none" x="43.2" width="14.4" y="474.85" connectorname="143" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector142terminal" fill="none" x="57.6" width="0" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label142" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="475.9" stroke="none" xmlns="http://www.w3.org/2000/svg">143</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="474.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">143</text>
+<line fill="none" y1="482.4" y2="482.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector141pin" fill="none" x="43.2" width="14.4" y="482.05" connectorname="142" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector141terminal" fill="none" x="57.6" width="0" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label141" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="483.1" stroke="none" xmlns="http://www.w3.org/2000/svg">142</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="481.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">142</text>
+<line fill="none" y1="489.6" y2="489.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector140pin" fill="none" x="43.2" width="14.4" y="489.25" connectorname="141" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector140terminal" fill="none" x="57.6" width="0" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label140" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="490.3" stroke="none" xmlns="http://www.w3.org/2000/svg">141</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="488.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">141</text>
+<line fill="none" y1="496.8" y2="496.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector139pin" fill="none" x="43.2" width="14.4" y="496.45" connectorname="140" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector139terminal" fill="none" x="57.6" width="0" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label139" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="497.5" stroke="none" xmlns="http://www.w3.org/2000/svg">140</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="495.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">140</text>
+<line fill="none" y1="504" y2="504" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector138pin" fill="none" x="43.2" width="14.4" y="503.65" connectorname="139" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector138terminal" fill="none" x="57.6" width="0" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label138" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="504.7" stroke="none" xmlns="http://www.w3.org/2000/svg">139</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="502.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">139</text>
+<line fill="none" y1="511.2" y2="511.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector137pin" fill="none" x="43.2" width="14.4" y="510.85" connectorname="138" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector137terminal" fill="none" x="57.6" width="0" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label137" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="511.9" stroke="none" xmlns="http://www.w3.org/2000/svg">138</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="510.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">138</text>
+<line fill="none" y1="518.4" y2="518.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector136pin" fill="none" x="43.2" width="14.4" y="518.05" connectorname="137" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector136terminal" fill="none" x="57.6" width="0" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label136" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="519.1" stroke="none" xmlns="http://www.w3.org/2000/svg">137</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="517.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">137</text>
+<line fill="none" y1="525.6" y2="525.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector135pin" fill="none" x="43.2" width="14.4" y="525.25" connectorname="136" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector135terminal" fill="none" x="57.6" width="0" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label135" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="526.3" stroke="none" xmlns="http://www.w3.org/2000/svg">136</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="524.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">136</text>
+<line fill="none" y1="532.8" y2="532.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector134pin" fill="none" x="43.2" width="14.4" y="532.45" connectorname="135" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector134terminal" fill="none" x="57.6" width="0" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label134" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="533.5" stroke="none" xmlns="http://www.w3.org/2000/svg">135</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="531.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">135</text>
+<line fill="none" y1="540" y2="540" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector133pin" fill="none" x="43.2" width="14.4" y="539.65" connectorname="134" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector133terminal" fill="none" x="57.6" width="0" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label133" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="540.7" stroke="none" xmlns="http://www.w3.org/2000/svg">134</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="538.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">134</text>
+<line fill="none" y1="547.2" y2="547.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector132pin" fill="none" x="43.2" width="14.4" y="546.85" connectorname="133" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector132terminal" fill="none" x="57.6" width="0" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label132" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="547.9" stroke="none" xmlns="http://www.w3.org/2000/svg">133</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="546.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">133</text>
+<line fill="none" y1="554.4" y2="554.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector131pin" fill="none" x="43.2" width="14.4" y="554.05" connectorname="132" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector131terminal" fill="none" x="57.6" width="0" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label131" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="555.1" stroke="none" xmlns="http://www.w3.org/2000/svg">132</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="553.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">132</text>
+<line fill="none" y1="561.6" y2="561.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector130pin" fill="none" x="43.2" width="14.4" y="561.25" connectorname="131" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector130terminal" fill="none" x="57.6" width="0" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label130" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="562.3" stroke="none" xmlns="http://www.w3.org/2000/svg">131</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="560.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">131</text>
+<line fill="none" y1="568.8" y2="568.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector129pin" fill="none" x="43.2" width="14.4" y="568.45" connectorname="130" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector129terminal" fill="none" x="57.6" width="0" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label129" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="569.5" stroke="none" xmlns="http://www.w3.org/2000/svg">130</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="567.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">130</text>
+<line fill="none" y1="576" y2="576" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector128pin" fill="none" x="43.2" width="14.4" y="575.65" connectorname="129" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector128terminal" fill="none" x="57.6" width="0" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label128" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="576.7" stroke="none" xmlns="http://www.w3.org/2000/svg">129</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="574.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">129</text>
+<line fill="none" y1="583.2" y2="583.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector127pin" fill="none" x="43.2" width="14.4" y="582.85" connectorname="128" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector127terminal" fill="none" x="57.6" width="0" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label127" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="583.9" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="582.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<line fill="none" y1="590.4" y2="590.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector126pin" fill="none" x="43.2" width="14.4" y="590.05" connectorname="127" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector126terminal" fill="none" x="57.6" width="0" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label126" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="591.1" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="589.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<line fill="none" y1="597.6" y2="597.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector125pin" fill="none" x="43.2" width="14.4" y="597.25" connectorname="126" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector125terminal" fill="none" x="57.6" width="0" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label125" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="598.3" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="596.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<line fill="none" y1="604.8" y2="604.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector124pin" fill="none" x="43.2" width="14.4" y="604.45" connectorname="125" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector124terminal" fill="none" x="57.6" width="0" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label124" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="605.5" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="603.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<line fill="none" y1="612" y2="612" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector123pin" fill="none" x="43.2" width="14.4" y="611.65" connectorname="124" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector123terminal" fill="none" x="57.6" width="0" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label123" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="612.7" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="610.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<line fill="none" y1="619.2" y2="619.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector122pin" fill="none" x="43.2" width="14.4" y="618.85" connectorname="123" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector122terminal" fill="none" x="57.6" width="0" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label122" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="619.9" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="618.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<line fill="none" y1="626.4" y2="626.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector121pin" fill="none" x="43.2" width="14.4" y="626.05" connectorname="122" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector121terminal" fill="none" x="57.6" width="0" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label121" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="627.1" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="625.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<line fill="none" y1="633.6" y2="633.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector120pin" fill="none" x="43.2" width="14.4" y="633.25" connectorname="121" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector120terminal" fill="none" x="57.6" width="0" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label120" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="634.3" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="632.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<line fill="none" y1="640.8" y2="640.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector119pin" fill="none" x="43.2" width="14.4" y="640.45" connectorname="120" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector119terminal" fill="none" x="57.6" width="0" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label119" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="641.5" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="639.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<line fill="none" y1="648" y2="648" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector118pin" fill="none" x="43.2" width="14.4" y="647.65" connectorname="119" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector118terminal" fill="none" x="57.6" width="0" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label118" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="648.7" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="646.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<line fill="none" y1="655.2" y2="655.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector117pin" fill="none" x="43.2" width="14.4" y="654.85" connectorname="118" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector117terminal" fill="none" x="57.6" width="0" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label117" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="655.9" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="654.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<line fill="none" y1="662.4" y2="662.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector116pin" fill="none" x="43.2" width="14.4" y="662.05" connectorname="117" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector116terminal" fill="none" x="57.6" width="0" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label116" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="663.1" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="661.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<line fill="none" y1="669.6" y2="669.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector115pin" fill="none" x="43.2" width="14.4" y="669.25" connectorname="116" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector115terminal" fill="none" x="57.6" width="0" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label115" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="670.3" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="668.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<line fill="none" y1="676.8" y2="676.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector114pin" fill="none" x="43.2" width="14.4" y="676.45" connectorname="115" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector114terminal" fill="none" x="57.6" width="0" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label114" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="677.5" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="675.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<line fill="none" y1="684" y2="684" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector113pin" fill="none" x="43.2" width="14.4" y="683.65" connectorname="114" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector113terminal" fill="none" x="57.6" width="0" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label113" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="684.7" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="682.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<line fill="none" y1="691.2" y2="691.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector112pin" fill="none" x="43.2" width="14.4" y="690.85" connectorname="113" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector112terminal" fill="none" x="57.6" width="0" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label112" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="691.9" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="690.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<line fill="none" y1="698.4" y2="698.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector111pin" fill="none" x="43.2" width="14.4" y="698.05" connectorname="112" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector111terminal" fill="none" x="57.6" width="0" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label111" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="699.1" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="697.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<line fill="none" y1="705.6" y2="705.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector110pin" fill="none" x="43.2" width="14.4" y="705.25" connectorname="111" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector110terminal" fill="none" x="57.6" width="0" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label110" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="706.3" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="704.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<line fill="none" y1="712.8" y2="712.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector109pin" fill="none" x="43.2" width="14.4" y="712.45" connectorname="110" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector109terminal" fill="none" x="57.6" width="0" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label109" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="713.5" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="711.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<line fill="none" y1="720" y2="720" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector108pin" fill="none" x="43.2" width="14.4" y="719.65" connectorname="109" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector108terminal" fill="none" x="57.6" width="0" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label108" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="720.698" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="718.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<line fill="none" y1="727.2" y2="727.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector107pin" fill="none" x="43.2" width="14.4" y="726.847" connectorname="108" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector107terminal" fill="none" x="57.6" width="0" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label107" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="727.898" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="726.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<line fill="none" y1="734.4" y2="734.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector106pin" fill="none" x="43.2" width="14.4" y="734.047" connectorname="107" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector106terminal" fill="none" x="57.6" width="0" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label106" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="735.098" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="733.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<line fill="none" y1="741.6" y2="741.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector105pin" fill="none" x="43.2" width="14.4" y="741.247" connectorname="106" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector105terminal" fill="none" x="57.6" width="0" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label105" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="742.298" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="740.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<line fill="none" y1="748.8" y2="748.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector104pin" fill="none" x="43.2" width="14.4" y="748.447" connectorname="105" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector104terminal" fill="none" x="57.6" width="0" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label104" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="749.498" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="747.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC24.svg
+++ b/svg/core/schematic/IC24.svg
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.3in' viewBox='0 0 50.4 93.6' >
+<g partID='59180'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="92.7" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="39.7" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="6.85" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="14.05" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="21.25" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="28.45" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="35.65" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="42.85" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="50.05" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="57.25" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="64.45" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" x="36" width="14.4" y="71.65" connectorname="15" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="14" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="13" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC256.svg
+++ b/svg/core/schematic/IC256.svg
@@ -1,0 +1,1288 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.8in' height='12.9in' viewBox='0 0 57.6 928.8' >
+<g partID='60060'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="927.9" fill="none" x="14.4" width="28.35" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="28.8" y="457.3" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" connectorName="33" x="0" width="14.4" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="0" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" connectorName="34" x="0" width="14.4" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="0" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" connectorName="35" x="0" width="14.4" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="0" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" connectorName="36" x="0" width="14.4" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="0" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" connectorName="37" x="0" width="14.4" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="0" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" connectorName="38" x="0" width="14.4" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="0" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" connectorName="39" x="0" width="14.4" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="0" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" connectorName="40" x="0" width="14.4" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="0" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" connectorName="41" x="0" width="14.4" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="0" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" connectorName="42" x="0" width="14.4" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="0" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" connectorName="43" x="0" width="14.4" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="0" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" connectorName="44" x="0" width="14.4" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="0" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" connectorName="45" x="0" width="14.4" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="0" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" connectorName="46" x="0" width="14.4" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="0" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" connectorName="47" x="0" width="14.4" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="0" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" connectorName="48" x="0" width="14.4" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="0" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" connectorName="49" x="0" width="14.4" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="0" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" connectorName="50" x="0" width="14.4" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="0" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" connectorName="51" x="0" width="14.4" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="0" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" connectorName="52" x="0" width="14.4" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="0" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" connectorName="53" x="0" width="14.4" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="0" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" connectorName="54" x="0" width="14.4" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="0" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" connectorName="55" x="0" width="14.4" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="0" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" connectorName="56" x="0" width="14.4" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="0" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" connectorName="57" x="0" width="14.4" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="0" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" connectorName="58" x="0" width="14.4" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="0" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" connectorName="59" x="0" width="14.4" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="0" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" connectorName="60" x="0" width="14.4" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="0" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" connectorName="61" x="0" width="14.4" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="0" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" connectorName="62" x="0" width="14.4" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="0" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" connectorName="63" x="0" width="14.4" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="0" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" connectorName="64" x="0" width="14.4" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="0" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="468" y2="468" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector64pin" fill="none" connectorName="65" x="0" width="14.4" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector64terminal" fill="none" x="0" width="0" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label64" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="468.7" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="466.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<line fill="none" y1="475.2" y2="475.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector65pin" fill="none" connectorName="66" x="0" width="14.4" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector65terminal" fill="none" x="0" width="0" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label65" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="475.9" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="474.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<line fill="none" y1="482.4" y2="482.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector66pin" fill="none" connectorName="67" x="0" width="14.4" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector66terminal" fill="none" x="0" width="0" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label66" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="483.1" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="481.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<line fill="none" y1="489.6" y2="489.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector67pin" fill="none" connectorName="68" x="0" width="14.4" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector67terminal" fill="none" x="0" width="0" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label67" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="490.3" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="488.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<line fill="none" y1="496.8" y2="496.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector68pin" fill="none" connectorName="69" x="0" width="14.4" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector68terminal" fill="none" x="0" width="0" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label68" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="497.5" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="495.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<line fill="none" y1="504" y2="504" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector69pin" fill="none" connectorName="70" x="0" width="14.4" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector69terminal" fill="none" x="0" width="0" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label69" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="504.7" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="502.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<line fill="none" y1="511.2" y2="511.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector70pin" fill="none" connectorName="71" x="0" width="14.4" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector70terminal" fill="none" x="0" width="0" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label70" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="511.9" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="510.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<line fill="none" y1="518.4" y2="518.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector71pin" fill="none" connectorName="72" x="0" width="14.4" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector71terminal" fill="none" x="0" width="0" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label71" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="519.1" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="517.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<line fill="none" y1="525.6" y2="525.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector72pin" fill="none" connectorName="73" x="0" width="14.4" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector72terminal" fill="none" x="0" width="0" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label72" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="526.3" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="524.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<line fill="none" y1="532.8" y2="532.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector73pin" fill="none" connectorName="74" x="0" width="14.4" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector73terminal" fill="none" x="0" width="0" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label73" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="533.5" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="531.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<line fill="none" y1="540" y2="540" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector74pin" fill="none" connectorName="75" x="0" width="14.4" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector74terminal" fill="none" x="0" width="0" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label74" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="540.7" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="538.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<line fill="none" y1="547.2" y2="547.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector75pin" fill="none" connectorName="76" x="0" width="14.4" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector75terminal" fill="none" x="0" width="0" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label75" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="547.9" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="546.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<line fill="none" y1="554.4" y2="554.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector76pin" fill="none" connectorName="77" x="0" width="14.4" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector76terminal" fill="none" x="0" width="0" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label76" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="555.1" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="553.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<line fill="none" y1="561.6" y2="561.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector77pin" fill="none" connectorName="78" x="0" width="14.4" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector77terminal" fill="none" x="0" width="0" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label77" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="562.3" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="560.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<line fill="none" y1="568.8" y2="568.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector78pin" fill="none" connectorName="79" x="0" width="14.4" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector78terminal" fill="none" x="0" width="0" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label78" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="569.5" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="567.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<line fill="none" y1="576" y2="576" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector79pin" fill="none" connectorName="80" x="0" width="14.4" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector79terminal" fill="none" x="0" width="0" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label79" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="576.7" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="574.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<line fill="none" y1="583.2" y2="583.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector80pin" fill="none" connectorName="81" x="0" width="14.4" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector80terminal" fill="none" x="0" width="0" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label80" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="583.9" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="582.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">81</text>
+<line fill="none" y1="590.4" y2="590.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector81pin" fill="none" connectorName="82" x="0" width="14.4" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector81terminal" fill="none" x="0" width="0" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label81" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="591.1" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="589.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">82</text>
+<line fill="none" y1="597.6" y2="597.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector82pin" fill="none" connectorName="83" x="0" width="14.4" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector82terminal" fill="none" x="0" width="0" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label82" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="598.3" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="596.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">83</text>
+<line fill="none" y1="604.8" y2="604.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector83pin" fill="none" connectorName="84" x="0" width="14.4" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector83terminal" fill="none" x="0" width="0" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label83" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="605.5" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="603.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">84</text>
+<line fill="none" y1="612" y2="612" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector84pin" fill="none" connectorName="85" x="0" width="14.4" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector84terminal" fill="none" x="0" width="0" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label84" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="612.7" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="610.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">85</text>
+<line fill="none" y1="619.2" y2="619.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector85pin" fill="none" connectorName="86" x="0" width="14.4" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector85terminal" fill="none" x="0" width="0" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label85" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="619.9" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="618.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">86</text>
+<line fill="none" y1="626.4" y2="626.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector86pin" fill="none" connectorName="87" x="0" width="14.4" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector86terminal" fill="none" x="0" width="0" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label86" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="627.1" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="625.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">87</text>
+<line fill="none" y1="633.6" y2="633.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector87pin" fill="none" connectorName="88" x="0" width="14.4" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector87terminal" fill="none" x="0" width="0" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label87" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="634.3" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="632.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">88</text>
+<line fill="none" y1="640.8" y2="640.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector88pin" fill="none" connectorName="89" x="0" width="14.4" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector88terminal" fill="none" x="0" width="0" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label88" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="641.5" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="639.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">89</text>
+<line fill="none" y1="648" y2="648" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector89pin" fill="none" connectorName="90" x="0" width="14.4" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector89terminal" fill="none" x="0" width="0" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label89" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="648.7" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="646.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">90</text>
+<line fill="none" y1="655.2" y2="655.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector90pin" fill="none" connectorName="91" x="0" width="14.4" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector90terminal" fill="none" x="0" width="0" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label90" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="655.9" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="654.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">91</text>
+<line fill="none" y1="662.4" y2="662.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector91pin" fill="none" connectorName="92" x="0" width="14.4" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector91terminal" fill="none" x="0" width="0" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label91" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="663.1" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="661.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">92</text>
+<line fill="none" y1="669.6" y2="669.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector92pin" fill="none" connectorName="93" x="0" width="14.4" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector92terminal" fill="none" x="0" width="0" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label92" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="670.3" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="668.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">93</text>
+<line fill="none" y1="676.8" y2="676.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector93pin" fill="none" connectorName="94" x="0" width="14.4" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector93terminal" fill="none" x="0" width="0" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label93" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="677.5" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="675.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">94</text>
+<line fill="none" y1="684" y2="684" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector94pin" fill="none" connectorName="95" x="0" width="14.4" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector94terminal" fill="none" x="0" width="0" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label94" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="684.7" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="682.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">95</text>
+<line fill="none" y1="691.2" y2="691.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector95pin" fill="none" connectorName="96" x="0" width="14.4" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector95terminal" fill="none" x="0" width="0" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label95" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="691.9" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="690.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">96</text>
+<line fill="none" y1="698.4" y2="698.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector96pin" fill="none" connectorName="97" x="0" width="14.4" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector96terminal" fill="none" x="0" width="0" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label96" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="699.1" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="697.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">97</text>
+<line fill="none" y1="705.6" y2="705.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector97pin" fill="none" connectorName="98" x="0" width="14.4" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector97terminal" fill="none" x="0" width="0" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label97" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="706.3" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="704.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">98</text>
+<line fill="none" y1="712.8" y2="712.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector98pin" fill="none" connectorName="99" x="0" width="14.4" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector98terminal" fill="none" x="0" width="0" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label98" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="713.5" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="711.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">99</text>
+<line fill="none" y1="720" y2="720" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector99pin" fill="none" connectorName="100" x="0" width="14.4" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector99terminal" fill="none" x="0" width="0" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label99" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="720.698" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="718.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">100</text>
+<line fill="none" y1="727.2" y2="727.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector100pin" fill="none" connectorName="101" x="0" width="14.4" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector100terminal" fill="none" x="0" width="0" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label100" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="727.898" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="726.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">101</text>
+<line fill="none" y1="734.4" y2="734.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector101pin" fill="none" connectorName="102" x="0" width="14.4" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector101terminal" fill="none" x="0" width="0" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label101" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="735.098" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="733.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">102</text>
+<line fill="none" y1="741.6" y2="741.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector102pin" fill="none" connectorName="103" x="0" width="14.4" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector102terminal" fill="none" x="0" width="0" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label102" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="742.298" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="740.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">103</text>
+<line fill="none" y1="748.8" y2="748.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector103pin" fill="none" connectorName="104" x="0" width="14.4" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector103terminal" fill="none" x="0" width="0" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label103" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="749.498" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="747.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">104</text>
+<line fill="none" y1="756" y2="756" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector104pin" fill="none" connectorName="105" x="0" width="14.4" y="755.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector104terminal" fill="none" x="0" width="0" y="755.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label104" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="756.698" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="754.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">105</text>
+<line fill="none" y1="763.2" y2="763.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector105pin" fill="none" connectorName="106" x="0" width="14.4" y="762.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector105terminal" fill="none" x="0" width="0" y="762.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label105" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="763.898" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="762.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">106</text>
+<line fill="none" y1="770.4" y2="770.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector106pin" fill="none" connectorName="107" x="0" width="14.4" y="770.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector106terminal" fill="none" x="0" width="0" y="770.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label106" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="771.098" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="769.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">107</text>
+<line fill="none" y1="777.6" y2="777.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector107pin" fill="none" connectorName="108" x="0" width="14.4" y="777.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector107terminal" fill="none" x="0" width="0" y="777.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label107" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="778.298" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="776.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">108</text>
+<line fill="none" y1="784.8" y2="784.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector108pin" fill="none" connectorName="109" x="0" width="14.4" y="784.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector108terminal" fill="none" x="0" width="0" y="784.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label108" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="785.498" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="783.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">109</text>
+<line fill="none" y1="792" y2="792" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector109pin" fill="none" connectorName="110" x="0" width="14.4" y="791.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector109terminal" fill="none" x="0" width="0" y="791.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label109" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="792.698" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="790.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">110</text>
+<line fill="none" y1="799.2" y2="799.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector110pin" fill="none" connectorName="111" x="0" width="14.4" y="798.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector110terminal" fill="none" x="0" width="0" y="798.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label110" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="799.898" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="798.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">111</text>
+<line fill="none" y1="806.4" y2="806.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector111pin" fill="none" connectorName="112" x="0" width="14.4" y="806.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector111terminal" fill="none" x="0" width="0" y="806.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label111" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="807.098" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="805.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">112</text>
+<line fill="none" y1="813.6" y2="813.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector112pin" fill="none" connectorName="113" x="0" width="14.4" y="813.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector112terminal" fill="none" x="0" width="0" y="813.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label112" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="814.298" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="812.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">113</text>
+<line fill="none" y1="820.8" y2="820.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector113pin" fill="none" connectorName="114" x="0" width="14.4" y="820.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector113terminal" fill="none" x="0" width="0" y="820.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label113" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="821.498" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="819.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">114</text>
+<line fill="none" y1="828" y2="828" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector114pin" fill="none" connectorName="115" x="0" width="14.4" y="827.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector114terminal" fill="none" x="0" width="0" y="827.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label114" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="828.698" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="826.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">115</text>
+<line fill="none" y1="835.2" y2="835.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector115pin" fill="none" connectorName="116" x="0" width="14.4" y="834.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector115terminal" fill="none" x="0" width="0" y="834.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label115" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="835.898" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="834.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">116</text>
+<line fill="none" y1="842.4" y2="842.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector116pin" fill="none" connectorName="117" x="0" width="14.4" y="842.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector116terminal" fill="none" x="0" width="0" y="842.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label116" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="843.098" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="841.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">117</text>
+<line fill="none" y1="849.6" y2="849.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector117pin" fill="none" connectorName="118" x="0" width="14.4" y="849.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector117terminal" fill="none" x="0" width="0" y="849.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label117" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="850.298" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="848.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">118</text>
+<line fill="none" y1="856.8" y2="856.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector118pin" fill="none" connectorName="119" x="0" width="14.4" y="856.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector118terminal" fill="none" x="0" width="0" y="856.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label118" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="857.498" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="855.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">119</text>
+<line fill="none" y1="864" y2="864" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector119pin" fill="none" connectorName="120" x="0" width="14.4" y="863.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector119terminal" fill="none" x="0" width="0" y="863.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label119" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="864.698" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="862.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">120</text>
+<line fill="none" y1="871.2" y2="871.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector120pin" fill="none" connectorName="121" x="0" width="14.4" y="870.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector120terminal" fill="none" x="0" width="0" y="870.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label120" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="871.898" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="870.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">121</text>
+<line fill="none" y1="878.4" y2="878.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector121pin" fill="none" connectorName="122" x="0" width="14.4" y="878.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector121terminal" fill="none" x="0" width="0" y="878.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label121" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="879.098" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="877.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">122</text>
+<line fill="none" y1="885.6" y2="885.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector122pin" fill="none" connectorName="123" x="0" width="14.4" y="885.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector122terminal" fill="none" x="0" width="0" y="885.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label122" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="886.298" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="884.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">123</text>
+<line fill="none" y1="892.8" y2="892.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector123pin" fill="none" connectorName="124" x="0" width="14.4" y="892.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector123terminal" fill="none" x="0" width="0" y="892.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label123" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="893.498" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="891.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">124</text>
+<line fill="none" y1="900" y2="900" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector124pin" fill="none" connectorName="125" x="0" width="14.4" y="899.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector124terminal" fill="none" x="0" width="0" y="899.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label124" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="900.698" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="898.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">125</text>
+<line fill="none" y1="907.2" y2="907.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector125pin" fill="none" connectorName="126" x="0" width="14.4" y="906.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector125terminal" fill="none" x="0" width="0" y="906.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label125" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="907.898" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="906.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">126</text>
+<line fill="none" y1="914.4" y2="914.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector126pin" fill="none" connectorName="127" x="0" width="14.4" y="914.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector126terminal" fill="none" x="0" width="0" y="914.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label126" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="915.098" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="913.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">127</text>
+<line fill="none" y1="921.6" y2="921.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector127pin" fill="none" connectorName="128" x="0" width="14.4" y="921.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector127terminal" fill="none" x="0" width="0" y="921.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label127" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="922.298" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="920.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">128</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector255pin" fill="none" x="43.2" width="14.4" y="6.85" connectorname="256" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector255terminal" fill="none" x="57.6" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label255" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">256</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">256</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector254pin" fill="none" x="43.2" width="14.4" y="14.05" connectorname="255" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector254terminal" fill="none" x="57.6" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label254" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">255</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">255</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector253pin" fill="none" x="43.2" width="14.4" y="21.25" connectorname="254" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector253terminal" fill="none" x="57.6" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label253" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">254</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">254</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector252pin" fill="none" x="43.2" width="14.4" y="28.45" connectorname="253" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector252terminal" fill="none" x="57.6" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label252" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">253</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">253</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector251pin" fill="none" x="43.2" width="14.4" y="35.65" connectorname="252" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector251terminal" fill="none" x="57.6" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label251" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">252</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">252</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector250pin" fill="none" x="43.2" width="14.4" y="42.85" connectorname="251" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector250terminal" fill="none" x="57.6" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label250" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">251</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">251</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector249pin" fill="none" x="43.2" width="14.4" y="50.05" connectorname="250" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector249terminal" fill="none" x="57.6" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label249" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">250</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">250</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector248pin" fill="none" x="43.2" width="14.4" y="57.25" connectorname="249" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector248terminal" fill="none" x="57.6" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label248" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">249</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">249</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector247pin" fill="none" x="43.2" width="14.4" y="64.45" connectorname="248" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector247terminal" fill="none" x="57.6" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label247" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">248</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">248</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector246pin" fill="none" x="43.2" width="14.4" y="71.65" connectorname="247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector246terminal" fill="none" x="57.6" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label246" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">247</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">247</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector245pin" fill="none" x="43.2" width="14.4" y="78.8501" connectorname="246" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector245terminal" fill="none" x="57.6" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label245" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">246</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">246</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector244pin" fill="none" x="43.2" width="14.4" y="86.0501" connectorname="245" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector244terminal" fill="none" x="57.6" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label244" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">245</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">245</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector243pin" fill="none" x="43.2" width="14.4" y="93.2501" connectorname="244" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector243terminal" fill="none" x="57.6" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label243" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">244</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">244</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector242pin" fill="none" x="43.2" width="14.4" y="100.45" connectorname="243" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector242terminal" fill="none" x="57.6" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label242" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">243</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">243</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector241pin" fill="none" x="43.2" width="14.4" y="107.65" connectorname="242" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector241terminal" fill="none" x="57.6" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label241" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">242</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">242</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector240pin" fill="none" x="43.2" width="14.4" y="114.85" connectorname="241" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector240terminal" fill="none" x="57.6" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label240" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">241</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">241</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector239pin" fill="none" x="43.2" width="14.4" y="122.05" connectorname="240" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector239terminal" fill="none" x="57.6" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label239" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">240</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">240</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector238pin" fill="none" x="43.2" width="14.4" y="129.25" connectorname="239" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector238terminal" fill="none" x="57.6" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label238" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">239</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">239</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector237pin" fill="none" x="43.2" width="14.4" y="136.45" connectorname="238" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector237terminal" fill="none" x="57.6" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label237" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">238</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">238</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector236pin" fill="none" x="43.2" width="14.4" y="143.65" connectorname="237" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector236terminal" fill="none" x="57.6" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label236" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">237</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">237</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector235pin" fill="none" x="43.2" width="14.4" y="150.85" connectorname="236" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector235terminal" fill="none" x="57.6" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label235" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">236</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">236</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector234pin" fill="none" x="43.2" width="14.4" y="158.05" connectorname="235" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector234terminal" fill="none" x="57.6" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label234" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">235</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">235</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector233pin" fill="none" x="43.2" width="14.4" y="165.25" connectorname="234" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector233terminal" fill="none" x="57.6" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label233" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">234</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">234</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector232pin" fill="none" x="43.2" width="14.4" y="172.45" connectorname="233" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector232terminal" fill="none" x="57.6" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label232" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">233</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">233</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector231pin" fill="none" x="43.2" width="14.4" y="179.65" connectorname="232" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector231terminal" fill="none" x="57.6" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label231" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">232</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">232</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector230pin" fill="none" x="43.2" width="14.4" y="186.85" connectorname="231" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector230terminal" fill="none" x="57.6" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label230" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">231</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">231</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector229pin" fill="none" x="43.2" width="14.4" y="194.05" connectorname="230" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector229terminal" fill="none" x="57.6" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label229" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">230</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">230</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector228pin" fill="none" x="43.2" width="14.4" y="201.25" connectorname="229" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector228terminal" fill="none" x="57.6" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label228" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">229</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">229</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector227pin" fill="none" x="43.2" width="14.4" y="208.45" connectorname="228" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector227terminal" fill="none" x="57.6" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label227" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">228</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">228</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector226pin" fill="none" x="43.2" width="14.4" y="215.65" connectorname="227" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector226terminal" fill="none" x="57.6" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label226" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">227</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">227</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector225pin" fill="none" x="43.2" width="14.4" y="222.85" connectorname="226" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector225terminal" fill="none" x="57.6" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label225" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">226</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">226</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector224pin" fill="none" x="43.2" width="14.4" y="230.05" connectorname="225" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector224terminal" fill="none" x="57.6" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label224" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">225</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">225</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector223pin" fill="none" x="43.2" width="14.4" y="237.25" connectorname="224" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector223terminal" fill="none" x="57.6" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label223" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">224</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">224</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector222pin" fill="none" x="43.2" width="14.4" y="244.45" connectorname="223" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector222terminal" fill="none" x="57.6" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label222" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">223</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">223</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector221pin" fill="none" x="43.2" width="14.4" y="251.65" connectorname="222" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector221terminal" fill="none" x="57.6" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label221" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">222</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">222</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector220pin" fill="none" x="43.2" width="14.4" y="258.85" connectorname="221" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector220terminal" fill="none" x="57.6" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label220" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">221</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">221</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector219pin" fill="none" x="43.2" width="14.4" y="266.05" connectorname="220" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector219terminal" fill="none" x="57.6" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label219" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">220</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">220</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector218pin" fill="none" x="43.2" width="14.4" y="273.25" connectorname="219" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector218terminal" fill="none" x="57.6" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label218" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">219</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">219</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector217pin" fill="none" x="43.2" width="14.4" y="280.45" connectorname="218" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector217terminal" fill="none" x="57.6" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label217" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">218</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">218</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector216pin" fill="none" x="43.2" width="14.4" y="287.65" connectorname="217" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector216terminal" fill="none" x="57.6" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label216" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">217</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">217</text>
+<line fill="none" y1="295.2" y2="295.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector215pin" fill="none" x="43.2" width="14.4" y="294.85" connectorname="216" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector215terminal" fill="none" x="57.6" width="0" y="294.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label215" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="295.9" stroke="none" xmlns="http://www.w3.org/2000/svg">216</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="294.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">216</text>
+<line fill="none" y1="302.4" y2="302.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector214pin" fill="none" x="43.2" width="14.4" y="302.05" connectorname="215" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector214terminal" fill="none" x="57.6" width="0" y="302.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label214" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="303.1" stroke="none" xmlns="http://www.w3.org/2000/svg">215</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="301.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">215</text>
+<line fill="none" y1="309.6" y2="309.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector213pin" fill="none" x="43.2" width="14.4" y="309.25" connectorname="214" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector213terminal" fill="none" x="57.6" width="0" y="309.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label213" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="310.3" stroke="none" xmlns="http://www.w3.org/2000/svg">214</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="308.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">214</text>
+<line fill="none" y1="316.8" y2="316.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector212pin" fill="none" x="43.2" width="14.4" y="316.45" connectorname="213" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector212terminal" fill="none" x="57.6" width="0" y="316.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label212" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="317.5" stroke="none" xmlns="http://www.w3.org/2000/svg">213</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="315.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">213</text>
+<line fill="none" y1="324" y2="324" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector211pin" fill="none" x="43.2" width="14.4" y="323.65" connectorname="212" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector211terminal" fill="none" x="57.6" width="0" y="323.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label211" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="324.7" stroke="none" xmlns="http://www.w3.org/2000/svg">212</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="322.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">212</text>
+<line fill="none" y1="331.2" y2="331.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector210pin" fill="none" x="43.2" width="14.4" y="330.85" connectorname="211" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector210terminal" fill="none" x="57.6" width="0" y="330.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label210" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="331.9" stroke="none" xmlns="http://www.w3.org/2000/svg">211</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="330.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">211</text>
+<line fill="none" y1="338.4" y2="338.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector209pin" fill="none" x="43.2" width="14.4" y="338.05" connectorname="210" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector209terminal" fill="none" x="57.6" width="0" y="338.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label209" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="339.1" stroke="none" xmlns="http://www.w3.org/2000/svg">210</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="337.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">210</text>
+<line fill="none" y1="345.6" y2="345.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector208pin" fill="none" x="43.2" width="14.4" y="345.25" connectorname="209" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector208terminal" fill="none" x="57.6" width="0" y="345.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label208" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="346.3" stroke="none" xmlns="http://www.w3.org/2000/svg">209</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="344.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">209</text>
+<line fill="none" y1="352.8" y2="352.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector207pin" fill="none" x="43.2" width="14.4" y="352.45" connectorname="208" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector207terminal" fill="none" x="57.6" width="0" y="352.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label207" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="353.5" stroke="none" xmlns="http://www.w3.org/2000/svg">208</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="351.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">208</text>
+<line fill="none" y1="360" y2="360" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector206pin" fill="none" x="43.2" width="14.4" y="359.65" connectorname="207" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector206terminal" fill="none" x="57.6" width="0" y="359.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label206" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="360.7" stroke="none" xmlns="http://www.w3.org/2000/svg">207</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="358.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">207</text>
+<line fill="none" y1="367.2" y2="367.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector205pin" fill="none" x="43.2" width="14.4" y="366.85" connectorname="206" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector205terminal" fill="none" x="57.6" width="0" y="366.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label205" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="367.9" stroke="none" xmlns="http://www.w3.org/2000/svg">206</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="366.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">206</text>
+<line fill="none" y1="374.4" y2="374.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector204pin" fill="none" x="43.2" width="14.4" y="374.05" connectorname="205" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector204terminal" fill="none" x="57.6" width="0" y="374.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label204" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="375.1" stroke="none" xmlns="http://www.w3.org/2000/svg">205</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="373.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">205</text>
+<line fill="none" y1="381.6" y2="381.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector203pin" fill="none" x="43.2" width="14.4" y="381.25" connectorname="204" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector203terminal" fill="none" x="57.6" width="0" y="381.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label203" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="382.3" stroke="none" xmlns="http://www.w3.org/2000/svg">204</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="380.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">204</text>
+<line fill="none" y1="388.8" y2="388.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector202pin" fill="none" x="43.2" width="14.4" y="388.45" connectorname="203" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector202terminal" fill="none" x="57.6" width="0" y="388.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label202" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="389.5" stroke="none" xmlns="http://www.w3.org/2000/svg">203</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="387.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">203</text>
+<line fill="none" y1="396" y2="396" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector201pin" fill="none" x="43.2" width="14.4" y="395.65" connectorname="202" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector201terminal" fill="none" x="57.6" width="0" y="395.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label201" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="396.7" stroke="none" xmlns="http://www.w3.org/2000/svg">202</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="394.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">202</text>
+<line fill="none" y1="403.2" y2="403.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector200pin" fill="none" x="43.2" width="14.4" y="402.85" connectorname="201" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector200terminal" fill="none" x="57.6" width="0" y="402.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label200" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="403.9" stroke="none" xmlns="http://www.w3.org/2000/svg">201</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="402.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">201</text>
+<line fill="none" y1="410.4" y2="410.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector199pin" fill="none" x="43.2" width="14.4" y="410.05" connectorname="200" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector199terminal" fill="none" x="57.6" width="0" y="410.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label199" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="411.1" stroke="none" xmlns="http://www.w3.org/2000/svg">200</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="409.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">200</text>
+<line fill="none" y1="417.6" y2="417.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector198pin" fill="none" x="43.2" width="14.4" y="417.25" connectorname="199" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector198terminal" fill="none" x="57.6" width="0" y="417.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label198" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="418.3" stroke="none" xmlns="http://www.w3.org/2000/svg">199</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="416.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">199</text>
+<line fill="none" y1="424.8" y2="424.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector197pin" fill="none" x="43.2" width="14.4" y="424.45" connectorname="198" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector197terminal" fill="none" x="57.6" width="0" y="424.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label197" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="425.5" stroke="none" xmlns="http://www.w3.org/2000/svg">198</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="423.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">198</text>
+<line fill="none" y1="432" y2="432" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector196pin" fill="none" x="43.2" width="14.4" y="431.65" connectorname="197" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector196terminal" fill="none" x="57.6" width="0" y="431.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label196" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="432.7" stroke="none" xmlns="http://www.w3.org/2000/svg">197</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="430.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">197</text>
+<line fill="none" y1="439.2" y2="439.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector195pin" fill="none" x="43.2" width="14.4" y="438.85" connectorname="196" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector195terminal" fill="none" x="57.6" width="0" y="438.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label195" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="439.9" stroke="none" xmlns="http://www.w3.org/2000/svg">196</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="438.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">196</text>
+<line fill="none" y1="446.4" y2="446.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector194pin" fill="none" x="43.2" width="14.4" y="446.05" connectorname="195" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector194terminal" fill="none" x="57.6" width="0" y="446.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label194" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="447.1" stroke="none" xmlns="http://www.w3.org/2000/svg">195</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="445.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">195</text>
+<line fill="none" y1="453.6" y2="453.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector193pin" fill="none" x="43.2" width="14.4" y="453.25" connectorname="194" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector193terminal" fill="none" x="57.6" width="0" y="453.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label193" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="454.3" stroke="none" xmlns="http://www.w3.org/2000/svg">194</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="452.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">194</text>
+<line fill="none" y1="460.8" y2="460.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector192pin" fill="none" x="43.2" width="14.4" y="460.45" connectorname="193" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector192terminal" fill="none" x="57.6" width="0" y="460.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label192" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="461.5" stroke="none" xmlns="http://www.w3.org/2000/svg">193</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="459.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">193</text>
+<line fill="none" y1="468" y2="468" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector191pin" fill="none" x="43.2" width="14.4" y="467.65" connectorname="192" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector191terminal" fill="none" x="57.6" width="0" y="467.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label191" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="468.7" stroke="none" xmlns="http://www.w3.org/2000/svg">192</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="466.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">192</text>
+<line fill="none" y1="475.2" y2="475.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector190pin" fill="none" x="43.2" width="14.4" y="474.85" connectorname="191" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector190terminal" fill="none" x="57.6" width="0" y="474.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label190" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="475.9" stroke="none" xmlns="http://www.w3.org/2000/svg">191</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="474.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">191</text>
+<line fill="none" y1="482.4" y2="482.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector189pin" fill="none" x="43.2" width="14.4" y="482.05" connectorname="190" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector189terminal" fill="none" x="57.6" width="0" y="482.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label189" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="483.1" stroke="none" xmlns="http://www.w3.org/2000/svg">190</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="481.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">190</text>
+<line fill="none" y1="489.6" y2="489.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector188pin" fill="none" x="43.2" width="14.4" y="489.25" connectorname="189" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector188terminal" fill="none" x="57.6" width="0" y="489.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label188" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="490.3" stroke="none" xmlns="http://www.w3.org/2000/svg">189</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="488.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">189</text>
+<line fill="none" y1="496.8" y2="496.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector187pin" fill="none" x="43.2" width="14.4" y="496.45" connectorname="188" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector187terminal" fill="none" x="57.6" width="0" y="496.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label187" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="497.5" stroke="none" xmlns="http://www.w3.org/2000/svg">188</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="495.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">188</text>
+<line fill="none" y1="504" y2="504" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector186pin" fill="none" x="43.2" width="14.4" y="503.65" connectorname="187" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector186terminal" fill="none" x="57.6" width="0" y="503.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label186" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="504.7" stroke="none" xmlns="http://www.w3.org/2000/svg">187</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="502.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">187</text>
+<line fill="none" y1="511.2" y2="511.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector185pin" fill="none" x="43.2" width="14.4" y="510.85" connectorname="186" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector185terminal" fill="none" x="57.6" width="0" y="510.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label185" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="511.9" stroke="none" xmlns="http://www.w3.org/2000/svg">186</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="510.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">186</text>
+<line fill="none" y1="518.4" y2="518.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector184pin" fill="none" x="43.2" width="14.4" y="518.05" connectorname="185" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector184terminal" fill="none" x="57.6" width="0" y="518.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label184" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="519.1" stroke="none" xmlns="http://www.w3.org/2000/svg">185</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="517.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">185</text>
+<line fill="none" y1="525.6" y2="525.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector183pin" fill="none" x="43.2" width="14.4" y="525.25" connectorname="184" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector183terminal" fill="none" x="57.6" width="0" y="525.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label183" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="526.3" stroke="none" xmlns="http://www.w3.org/2000/svg">184</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="524.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">184</text>
+<line fill="none" y1="532.8" y2="532.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector182pin" fill="none" x="43.2" width="14.4" y="532.45" connectorname="183" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector182terminal" fill="none" x="57.6" width="0" y="532.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label182" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="533.5" stroke="none" xmlns="http://www.w3.org/2000/svg">183</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="531.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">183</text>
+<line fill="none" y1="540" y2="540" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector181pin" fill="none" x="43.2" width="14.4" y="539.65" connectorname="182" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector181terminal" fill="none" x="57.6" width="0" y="539.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label181" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="540.7" stroke="none" xmlns="http://www.w3.org/2000/svg">182</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="538.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">182</text>
+<line fill="none" y1="547.2" y2="547.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector180pin" fill="none" x="43.2" width="14.4" y="546.85" connectorname="181" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector180terminal" fill="none" x="57.6" width="0" y="546.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label180" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="547.9" stroke="none" xmlns="http://www.w3.org/2000/svg">181</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="546.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">181</text>
+<line fill="none" y1="554.4" y2="554.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector179pin" fill="none" x="43.2" width="14.4" y="554.05" connectorname="180" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector179terminal" fill="none" x="57.6" width="0" y="554.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label179" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="555.1" stroke="none" xmlns="http://www.w3.org/2000/svg">180</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="553.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">180</text>
+<line fill="none" y1="561.6" y2="561.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector178pin" fill="none" x="43.2" width="14.4" y="561.25" connectorname="179" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector178terminal" fill="none" x="57.6" width="0" y="561.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label178" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="562.3" stroke="none" xmlns="http://www.w3.org/2000/svg">179</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="560.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">179</text>
+<line fill="none" y1="568.8" y2="568.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector177pin" fill="none" x="43.2" width="14.4" y="568.45" connectorname="178" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector177terminal" fill="none" x="57.6" width="0" y="568.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label177" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="569.5" stroke="none" xmlns="http://www.w3.org/2000/svg">178</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="567.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">178</text>
+<line fill="none" y1="576" y2="576" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector176pin" fill="none" x="43.2" width="14.4" y="575.65" connectorname="177" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector176terminal" fill="none" x="57.6" width="0" y="575.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label176" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="576.7" stroke="none" xmlns="http://www.w3.org/2000/svg">177</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="574.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">177</text>
+<line fill="none" y1="583.2" y2="583.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector175pin" fill="none" x="43.2" width="14.4" y="582.85" connectorname="176" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector175terminal" fill="none" x="57.6" width="0" y="582.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label175" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="583.9" stroke="none" xmlns="http://www.w3.org/2000/svg">176</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="582.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">176</text>
+<line fill="none" y1="590.4" y2="590.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector174pin" fill="none" x="43.2" width="14.4" y="590.05" connectorname="175" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector174terminal" fill="none" x="57.6" width="0" y="590.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label174" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="591.1" stroke="none" xmlns="http://www.w3.org/2000/svg">175</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="589.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">175</text>
+<line fill="none" y1="597.6" y2="597.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector173pin" fill="none" x="43.2" width="14.4" y="597.25" connectorname="174" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector173terminal" fill="none" x="57.6" width="0" y="597.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label173" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="598.3" stroke="none" xmlns="http://www.w3.org/2000/svg">174</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="596.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">174</text>
+<line fill="none" y1="604.8" y2="604.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector172pin" fill="none" x="43.2" width="14.4" y="604.45" connectorname="173" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector172terminal" fill="none" x="57.6" width="0" y="604.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label172" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="605.5" stroke="none" xmlns="http://www.w3.org/2000/svg">173</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="603.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">173</text>
+<line fill="none" y1="612" y2="612" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector171pin" fill="none" x="43.2" width="14.4" y="611.65" connectorname="172" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector171terminal" fill="none" x="57.6" width="0" y="611.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label171" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="612.7" stroke="none" xmlns="http://www.w3.org/2000/svg">172</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="610.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">172</text>
+<line fill="none" y1="619.2" y2="619.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector170pin" fill="none" x="43.2" width="14.4" y="618.85" connectorname="171" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector170terminal" fill="none" x="57.6" width="0" y="618.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label170" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="619.9" stroke="none" xmlns="http://www.w3.org/2000/svg">171</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="618.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">171</text>
+<line fill="none" y1="626.4" y2="626.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector169pin" fill="none" x="43.2" width="14.4" y="626.05" connectorname="170" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector169terminal" fill="none" x="57.6" width="0" y="626.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label169" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="627.1" stroke="none" xmlns="http://www.w3.org/2000/svg">170</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="625.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">170</text>
+<line fill="none" y1="633.6" y2="633.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector168pin" fill="none" x="43.2" width="14.4" y="633.25" connectorname="169" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector168terminal" fill="none" x="57.6" width="0" y="633.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label168" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="634.3" stroke="none" xmlns="http://www.w3.org/2000/svg">169</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="632.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">169</text>
+<line fill="none" y1="640.8" y2="640.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector167pin" fill="none" x="43.2" width="14.4" y="640.45" connectorname="168" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector167terminal" fill="none" x="57.6" width="0" y="640.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label167" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="641.5" stroke="none" xmlns="http://www.w3.org/2000/svg">168</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="639.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">168</text>
+<line fill="none" y1="648" y2="648" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector166pin" fill="none" x="43.2" width="14.4" y="647.65" connectorname="167" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector166terminal" fill="none" x="57.6" width="0" y="647.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label166" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="648.7" stroke="none" xmlns="http://www.w3.org/2000/svg">167</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="646.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">167</text>
+<line fill="none" y1="655.2" y2="655.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector165pin" fill="none" x="43.2" width="14.4" y="654.85" connectorname="166" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector165terminal" fill="none" x="57.6" width="0" y="654.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label165" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="655.9" stroke="none" xmlns="http://www.w3.org/2000/svg">166</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="654.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">166</text>
+<line fill="none" y1="662.4" y2="662.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector164pin" fill="none" x="43.2" width="14.4" y="662.05" connectorname="165" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector164terminal" fill="none" x="57.6" width="0" y="662.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label164" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="663.1" stroke="none" xmlns="http://www.w3.org/2000/svg">165</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="661.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">165</text>
+<line fill="none" y1="669.6" y2="669.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector163pin" fill="none" x="43.2" width="14.4" y="669.25" connectorname="164" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector163terminal" fill="none" x="57.6" width="0" y="669.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label163" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="670.3" stroke="none" xmlns="http://www.w3.org/2000/svg">164</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="668.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">164</text>
+<line fill="none" y1="676.8" y2="676.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector162pin" fill="none" x="43.2" width="14.4" y="676.45" connectorname="163" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector162terminal" fill="none" x="57.6" width="0" y="676.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label162" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="677.5" stroke="none" xmlns="http://www.w3.org/2000/svg">163</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="675.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">163</text>
+<line fill="none" y1="684" y2="684" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector161pin" fill="none" x="43.2" width="14.4" y="683.65" connectorname="162" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector161terminal" fill="none" x="57.6" width="0" y="683.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label161" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="684.7" stroke="none" xmlns="http://www.w3.org/2000/svg">162</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="682.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">162</text>
+<line fill="none" y1="691.2" y2="691.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector160pin" fill="none" x="43.2" width="14.4" y="690.85" connectorname="161" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector160terminal" fill="none" x="57.6" width="0" y="690.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label160" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="691.9" stroke="none" xmlns="http://www.w3.org/2000/svg">161</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="690.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">161</text>
+<line fill="none" y1="698.4" y2="698.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector159pin" fill="none" x="43.2" width="14.4" y="698.05" connectorname="160" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector159terminal" fill="none" x="57.6" width="0" y="698.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label159" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="699.1" stroke="none" xmlns="http://www.w3.org/2000/svg">160</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="697.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">160</text>
+<line fill="none" y1="705.6" y2="705.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector158pin" fill="none" x="43.2" width="14.4" y="705.25" connectorname="159" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector158terminal" fill="none" x="57.6" width="0" y="705.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label158" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="706.3" stroke="none" xmlns="http://www.w3.org/2000/svg">159</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="704.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">159</text>
+<line fill="none" y1="712.8" y2="712.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector157pin" fill="none" x="43.2" width="14.4" y="712.45" connectorname="158" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector157terminal" fill="none" x="57.6" width="0" y="712.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label157" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="713.5" stroke="none" xmlns="http://www.w3.org/2000/svg">158</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="711.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">158</text>
+<line fill="none" y1="720" y2="720" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector156pin" fill="none" x="43.2" width="14.4" y="719.65" connectorname="157" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector156terminal" fill="none" x="57.6" width="0" y="719.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label156" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="720.698" stroke="none" xmlns="http://www.w3.org/2000/svg">157</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="718.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">157</text>
+<line fill="none" y1="727.2" y2="727.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector155pin" fill="none" x="43.2" width="14.4" y="726.847" connectorname="156" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector155terminal" fill="none" x="57.6" width="0" y="726.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label155" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="727.898" stroke="none" xmlns="http://www.w3.org/2000/svg">156</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="726.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">156</text>
+<line fill="none" y1="734.4" y2="734.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector154pin" fill="none" x="43.2" width="14.4" y="734.047" connectorname="155" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector154terminal" fill="none" x="57.6" width="0" y="734.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label154" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="735.098" stroke="none" xmlns="http://www.w3.org/2000/svg">155</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="733.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">155</text>
+<line fill="none" y1="741.6" y2="741.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector153pin" fill="none" x="43.2" width="14.4" y="741.247" connectorname="154" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector153terminal" fill="none" x="57.6" width="0" y="741.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label153" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="742.298" stroke="none" xmlns="http://www.w3.org/2000/svg">154</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="740.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">154</text>
+<line fill="none" y1="748.8" y2="748.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector152pin" fill="none" x="43.2" width="14.4" y="748.447" connectorname="153" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector152terminal" fill="none" x="57.6" width="0" y="748.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label152" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="749.498" stroke="none" xmlns="http://www.w3.org/2000/svg">153</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="747.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">153</text>
+<line fill="none" y1="756" y2="756" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector151pin" fill="none" x="43.2" width="14.4" y="755.647" connectorname="152" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector151terminal" fill="none" x="57.6" width="0" y="755.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label151" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="756.698" stroke="none" xmlns="http://www.w3.org/2000/svg">152</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="754.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">152</text>
+<line fill="none" y1="763.2" y2="763.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector150pin" fill="none" x="43.2" width="14.4" y="762.847" connectorname="151" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector150terminal" fill="none" x="57.6" width="0" y="762.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label150" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="763.898" stroke="none" xmlns="http://www.w3.org/2000/svg">151</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="762.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">151</text>
+<line fill="none" y1="770.4" y2="770.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector149pin" fill="none" x="43.2" width="14.4" y="770.047" connectorname="150" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector149terminal" fill="none" x="57.6" width="0" y="770.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label149" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="771.098" stroke="none" xmlns="http://www.w3.org/2000/svg">150</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="769.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">150</text>
+<line fill="none" y1="777.6" y2="777.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector148pin" fill="none" x="43.2" width="14.4" y="777.247" connectorname="149" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector148terminal" fill="none" x="57.6" width="0" y="777.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label148" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="778.298" stroke="none" xmlns="http://www.w3.org/2000/svg">149</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="776.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">149</text>
+<line fill="none" y1="784.8" y2="784.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector147pin" fill="none" x="43.2" width="14.4" y="784.447" connectorname="148" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector147terminal" fill="none" x="57.6" width="0" y="784.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label147" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="785.498" stroke="none" xmlns="http://www.w3.org/2000/svg">148</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="783.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">148</text>
+<line fill="none" y1="792" y2="792" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector146pin" fill="none" x="43.2" width="14.4" y="791.647" connectorname="147" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector146terminal" fill="none" x="57.6" width="0" y="791.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label146" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="792.698" stroke="none" xmlns="http://www.w3.org/2000/svg">147</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="790.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">147</text>
+<line fill="none" y1="799.2" y2="799.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector145pin" fill="none" x="43.2" width="14.4" y="798.847" connectorname="146" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector145terminal" fill="none" x="57.6" width="0" y="798.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label145" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="799.898" stroke="none" xmlns="http://www.w3.org/2000/svg">146</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="798.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">146</text>
+<line fill="none" y1="806.4" y2="806.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector144pin" fill="none" x="43.2" width="14.4" y="806.047" connectorname="145" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector144terminal" fill="none" x="57.6" width="0" y="806.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label144" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="807.098" stroke="none" xmlns="http://www.w3.org/2000/svg">145</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="805.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">145</text>
+<line fill="none" y1="813.6" y2="813.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector143pin" fill="none" x="43.2" width="14.4" y="813.247" connectorname="144" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector143terminal" fill="none" x="57.6" width="0" y="813.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label143" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="814.298" stroke="none" xmlns="http://www.w3.org/2000/svg">144</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="812.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">144</text>
+<line fill="none" y1="820.8" y2="820.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector142pin" fill="none" x="43.2" width="14.4" y="820.447" connectorname="143" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector142terminal" fill="none" x="57.6" width="0" y="820.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label142" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="821.498" stroke="none" xmlns="http://www.w3.org/2000/svg">143</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="819.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">143</text>
+<line fill="none" y1="828" y2="828" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector141pin" fill="none" x="43.2" width="14.4" y="827.647" connectorname="142" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector141terminal" fill="none" x="57.6" width="0" y="827.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label141" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="828.698" stroke="none" xmlns="http://www.w3.org/2000/svg">142</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="826.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">142</text>
+<line fill="none" y1="835.2" y2="835.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector140pin" fill="none" x="43.2" width="14.4" y="834.847" connectorname="141" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector140terminal" fill="none" x="57.6" width="0" y="834.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label140" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="835.898" stroke="none" xmlns="http://www.w3.org/2000/svg">141</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="834.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">141</text>
+<line fill="none" y1="842.4" y2="842.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector139pin" fill="none" x="43.2" width="14.4" y="842.047" connectorname="140" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector139terminal" fill="none" x="57.6" width="0" y="842.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label139" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="843.098" stroke="none" xmlns="http://www.w3.org/2000/svg">140</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="841.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">140</text>
+<line fill="none" y1="849.6" y2="849.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector138pin" fill="none" x="43.2" width="14.4" y="849.247" connectorname="139" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector138terminal" fill="none" x="57.6" width="0" y="849.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label138" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="850.298" stroke="none" xmlns="http://www.w3.org/2000/svg">139</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="848.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">139</text>
+<line fill="none" y1="856.8" y2="856.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector137pin" fill="none" x="43.2" width="14.4" y="856.447" connectorname="138" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector137terminal" fill="none" x="57.6" width="0" y="856.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label137" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="857.498" stroke="none" xmlns="http://www.w3.org/2000/svg">138</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="855.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">138</text>
+<line fill="none" y1="864" y2="864" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector136pin" fill="none" x="43.2" width="14.4" y="863.647" connectorname="137" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector136terminal" fill="none" x="57.6" width="0" y="863.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label136" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="864.698" stroke="none" xmlns="http://www.w3.org/2000/svg">137</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="862.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">137</text>
+<line fill="none" y1="871.2" y2="871.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector135pin" fill="none" x="43.2" width="14.4" y="870.847" connectorname="136" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector135terminal" fill="none" x="57.6" width="0" y="870.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label135" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="871.898" stroke="none" xmlns="http://www.w3.org/2000/svg">136</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="870.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">136</text>
+<line fill="none" y1="878.4" y2="878.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector134pin" fill="none" x="43.2" width="14.4" y="878.047" connectorname="135" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector134terminal" fill="none" x="57.6" width="0" y="878.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label134" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="879.098" stroke="none" xmlns="http://www.w3.org/2000/svg">135</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="877.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">135</text>
+<line fill="none" y1="885.6" y2="885.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector133pin" fill="none" x="43.2" width="14.4" y="885.247" connectorname="134" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector133terminal" fill="none" x="57.6" width="0" y="885.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label133" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="886.298" stroke="none" xmlns="http://www.w3.org/2000/svg">134</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="884.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">134</text>
+<line fill="none" y1="892.8" y2="892.8" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector132pin" fill="none" x="43.2" width="14.4" y="892.447" connectorname="133" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector132terminal" fill="none" x="57.6" width="0" y="892.447" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label132" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="893.498" stroke="none" xmlns="http://www.w3.org/2000/svg">133</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="891.749" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">133</text>
+<line fill="none" y1="900" y2="900" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector131pin" fill="none" x="43.2" width="14.4" y="899.647" connectorname="132" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector131terminal" fill="none" x="57.6" width="0" y="899.647" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label131" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="900.698" stroke="none" xmlns="http://www.w3.org/2000/svg">132</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="898.949" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">132</text>
+<line fill="none" y1="907.2" y2="907.2" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector130pin" fill="none" x="43.2" width="14.4" y="906.847" connectorname="131" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector130terminal" fill="none" x="57.6" width="0" y="906.847" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label130" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="907.898" stroke="none" xmlns="http://www.w3.org/2000/svg">131</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="906.149" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">131</text>
+<line fill="none" y1="914.4" y2="914.4" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector129pin" fill="none" x="43.2" width="14.4" y="914.047" connectorname="130" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector129terminal" fill="none" x="57.6" width="0" y="914.047" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label129" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="915.098" stroke="none" xmlns="http://www.w3.org/2000/svg">130</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="913.349" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">130</text>
+<line fill="none" y1="921.6" y2="921.6" stroke-linejoin="round" stroke-width="0.699998" x1="42.85" stroke-linecap="round" x2="57.25" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector128pin" fill="none" x="43.2" width="14.4" y="921.247" connectorname="129" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector128terminal" fill="none" x="57.6" width="0" y="921.247" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label128" fill="#8c8c8c" font-family="'Droid Sans'" x="41.8" y="922.298" stroke="none" xmlns="http://www.w3.org/2000/svg">129</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="50.4" y="920.549" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">129</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC28.svg
+++ b/svg/core/schematic/IC28.svg
@@ -1,0 +1,148 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.5in' viewBox='0 0 50.4 108' >
+<g partID='59240'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="107.1" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="46.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="6.85" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="14.05" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="21.25" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="28.45" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="35.65" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="42.85" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="50.05" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="57.25" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="64.45" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="71.65" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" x="36" width="14.4" y="100.45" connectorname="15" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC30.svg
+++ b/svg/core/schematic/IC30.svg
@@ -1,0 +1,158 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.6in' viewBox='0 0 50.4 115.2' >
+<g partID='59300'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="114.3" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="54.1" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="6.85" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="14.05" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="21.25" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="28.45" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="35.65" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="42.85" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="50.05" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="57.25" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="64.45" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="71.65" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="100.45" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" x="36" width="14.4" y="107.65" connectorname="16" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC32.svg
+++ b/svg/core/schematic/IC32.svg
@@ -1,0 +1,168 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.7in' viewBox='0 0 50.4 122.4' >
+<g partID='59360'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="121.5" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="54.1" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" x="36" width="14.4" y="6.85" connectorname="32" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" x="36" width="14.4" y="14.05" connectorname="31" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="21.25" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="28.45" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="35.65" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="42.85" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="50.05" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="57.25" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="64.45" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="71.65" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="100.45" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" x="36" width="14.4" y="107.65" connectorname="18" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" x="36" width="14.4" y="114.85" connectorname="17" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC36.svg
+++ b/svg/core/schematic/IC36.svg
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='1.9in' viewBox='0 0 50.4 136.8' >
+<g partID='59420'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="135.9" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="61.3" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" x="36" width="14.4" y="6.85" connectorname="36" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" x="36" width="14.4" y="14.05" connectorname="35" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" x="36" width="14.4" y="21.25" connectorname="34" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" x="36" width="14.4" y="28.45" connectorname="33" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" x="36" width="14.4" y="35.65" connectorname="32" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" x="36" width="14.4" y="42.85" connectorname="31" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="50.05" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="57.25" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="64.45" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="71.65" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="100.45" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="107.65" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="114.85" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" x="36" width="14.4" y="122.05" connectorname="20" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" x="36" width="14.4" y="129.25" connectorname="19" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC4.svg
+++ b/svg/core/schematic/IC4.svg
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.6in' height='0.3in' viewBox='0 0 43.2 21.6' >
+<g partID='58560'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="20.7" fill="none" x="14.4" width="13.95" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="21.6" y="7.2" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" x="28.8" width="14.4" y="6.85" connectorname="4" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="43.2" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" x="28.8" width="14.4" y="14.05" connectorname="3" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="43.2" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC40.svg
+++ b/svg/core/schematic/IC40.svg
@@ -1,0 +1,208 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='2.1in' viewBox='0 0 50.4 151.2' >
+<g partID='59500'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="150.3" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="68.5" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" x="36" width="14.4" y="6.85" connectorname="40" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" x="36" width="14.4" y="14.05" connectorname="39" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" x="36" width="14.4" y="21.25" connectorname="38" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" x="36" width="14.4" y="28.45" connectorname="37" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" x="36" width="14.4" y="35.65" connectorname="36" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" x="36" width="14.4" y="42.85" connectorname="35" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" x="36" width="14.4" y="50.05" connectorname="34" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" x="36" width="14.4" y="57.25" connectorname="33" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" x="36" width="14.4" y="64.45" connectorname="32" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" x="36" width="14.4" y="71.65" connectorname="31" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="100.45" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="107.65" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="114.85" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="122.05" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="129.25" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" x="36" width="14.4" y="136.45" connectorname="22" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="50.4" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" x="36" width="14.4" y="143.65" connectorname="21" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="50.4" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC44.svg
+++ b/svg/core/schematic/IC44.svg
@@ -1,0 +1,228 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='2.3in' viewBox='0 0 50.4 165.6' >
+<g partID='59560'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="164.7" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="75.7001" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" x="36" width="14.4" y="6.85" connectorname="44" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" x="36" width="14.4" y="14.05" connectorname="43" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" x="36" width="14.4" y="21.25" connectorname="42" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" x="36" width="14.4" y="28.45" connectorname="41" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" x="36" width="14.4" y="35.65" connectorname="40" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" x="36" width="14.4" y="42.85" connectorname="39" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" x="36" width="14.4" y="50.05" connectorname="38" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" x="36" width="14.4" y="57.25" connectorname="37" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" x="36" width="14.4" y="64.45" connectorname="36" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" x="36" width="14.4" y="71.65" connectorname="35" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="34" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="33" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="32" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" x="36" width="14.4" y="100.45" connectorname="31" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="107.65" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="114.85" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="122.05" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="129.25" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="136.45" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="143.65" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" x="36" width="14.4" y="150.85" connectorname="24" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="50.4" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" x="36" width="14.4" y="158.05" connectorname="23" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="50.4" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC48.svg
+++ b/svg/core/schematic/IC48.svg
@@ -1,0 +1,248 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='2.5in' viewBox='0 0 50.4 180' >
+<g partID='59620'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="179.1" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="82.9001" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" x="36" width="14.4" y="6.85" connectorname="48" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" x="36" width="14.4" y="14.05" connectorname="47" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" x="36" width="14.4" y="21.25" connectorname="46" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" x="36" width="14.4" y="28.45" connectorname="45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" x="36" width="14.4" y="35.65" connectorname="44" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" x="36" width="14.4" y="42.85" connectorname="43" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" x="36" width="14.4" y="50.05" connectorname="42" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" x="36" width="14.4" y="57.25" connectorname="41" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" x="36" width="14.4" y="64.45" connectorname="40" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" x="36" width="14.4" y="71.65" connectorname="39" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="38" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="37" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="36" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" x="36" width="14.4" y="100.45" connectorname="35" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" x="36" width="14.4" y="107.65" connectorname="34" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" x="36" width="14.4" y="114.85" connectorname="33" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" x="36" width="14.4" y="122.05" connectorname="32" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" x="36" width="14.4" y="129.25" connectorname="31" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" x="36" width="14.4" y="136.45" connectorname="30" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="50.4" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" x="36" width="14.4" y="143.65" connectorname="29" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="50.4" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" x="36" width="14.4" y="150.85" connectorname="28" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="50.4" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" x="36" width="14.4" y="158.05" connectorname="27" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="50.4" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" x="36" width="14.4" y="165.25" connectorname="26" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="50.4" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" x="36" width="14.4" y="172.45" connectorname="25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="50.4" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC5.svg
+++ b/svg/core/schematic/IC5.svg
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.6in' height='0.4in' viewBox='0 0 43.2 28.8' >
+<g partID='58500'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="27.9" fill="none" x="14.4" width="13.95" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="21.6" y="10.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" x="28.8" width="14.4" y="14.05" connectorname="5" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="43.2" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" x="28.8" width="14.4" y="21.25" connectorname="4" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="43.2" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC6.svg
+++ b/svg/core/schematic/IC6.svg
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.6in' height='0.4in' viewBox='0 0 43.2 28.8' >
+<g partID='58500'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="27.9" fill="none" x="14.4" width="13.95" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="21.6" y="10.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" x="28.8" width="14.4" y="6.85" connectorname="6" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="43.2" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" x="28.8" width="14.4" y="14.05" connectorname="5" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="43.2" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" x="28.8" width="14.4" y="21.25" connectorname="4" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="43.2" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC64.svg
+++ b/svg/core/schematic/IC64.svg
@@ -1,0 +1,328 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='3.3in' viewBox='0 0 50.4 237.6' >
+<g partID='59680'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="236.7" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="111.7" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" x="36" width="14.4" y="6.85" connectorname="64" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" x="36" width="14.4" y="14.05" connectorname="63" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" x="36" width="14.4" y="21.25" connectorname="62" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" x="36" width="14.4" y="28.45" connectorname="61" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" x="36" width="14.4" y="35.65" connectorname="60" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" x="36" width="14.4" y="42.85" connectorname="59" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" x="36" width="14.4" y="50.05" connectorname="58" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" x="36" width="14.4" y="57.25" connectorname="57" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" x="36" width="14.4" y="64.45" connectorname="56" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" x="36" width="14.4" y="71.65" connectorname="55" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="54" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="53" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="52" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" x="36" width="14.4" y="100.45" connectorname="51" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" x="36" width="14.4" y="107.65" connectorname="50" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" x="36" width="14.4" y="114.85" connectorname="49" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" x="36" width="14.4" y="122.05" connectorname="48" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" x="36" width="14.4" y="129.25" connectorname="47" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" x="36" width="14.4" y="136.45" connectorname="46" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="50.4" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" x="36" width="14.4" y="143.65" connectorname="45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="50.4" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" x="36" width="14.4" y="150.85" connectorname="44" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="50.4" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" x="36" width="14.4" y="158.05" connectorname="43" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="50.4" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" x="36" width="14.4" y="165.25" connectorname="42" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="50.4" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" x="36" width="14.4" y="172.45" connectorname="41" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="50.4" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" x="36" width="14.4" y="179.65" connectorname="40" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="50.4" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" x="36" width="14.4" y="186.85" connectorname="39" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="50.4" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" x="36" width="14.4" y="194.05" connectorname="38" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="50.4" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" x="36" width="14.4" y="201.25" connectorname="37" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="50.4" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" x="36" width="14.4" y="208.45" connectorname="36" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="50.4" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" x="36" width="14.4" y="215.65" connectorname="35" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="50.4" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" x="36" width="14.4" y="222.85" connectorname="34" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="50.4" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" x="36" width="14.4" y="230.05" connectorname="33" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="50.4" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC8.svg
+++ b/svg/core/schematic/IC8.svg
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.6in' height='0.5in' viewBox='0 0 43.2 36' >
+<g partID='58620'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="35.1" fill="none" x="14.4" width="13.95" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="21.6" y="10.9" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" x="28.8" width="14.4" y="6.85" connectorname="8" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="43.2" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" x="28.8" width="14.4" y="14.05" connectorname="7" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="43.2" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" x="28.8" width="14.4" y="21.25" connectorname="6" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="43.2" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="28.45" stroke-linecap="round" x2="42.85" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" x="28.8" width="14.4" y="28.45" connectorname="5" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="43.2" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="27.4" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="36" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/IC80.svg
+++ b/svg/core/schematic/IC80.svg
@@ -1,0 +1,408 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.2' baseProfile='tiny' x='0in' y='0in' width='0.7in' height='4.1in' viewBox='0 0 50.4 295.2' >
+<g partID='59740'><g id="schematic" xmlns="http://www.w3.org/2000/svg">
+<rect height="294.3" fill="none" x="14.4" width="21.15" y="0.45" stroke-linejoin="round" stroke-width="0.9" stroke-linecap="round" stroke="#000000" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="middle" font-size="3.5" id="label" fill="#000000" font-family="'Droid Sans'" x="25.2" y="140.5" stroke="none" xmlns="http://www.w3.org/2000/svg">IC</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector0pin" fill="none" connectorName="1" x="0" width="14.4" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector0terminal" fill="none" x="0" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label0" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">1</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector1pin" fill="none" connectorName="2" x="0" width="14.4" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector1terminal" fill="none" x="0" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label1" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">2</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector2pin" fill="none" connectorName="3" x="0" width="14.4" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector2terminal" fill="none" x="0" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label2" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">3</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector3pin" fill="none" connectorName="4" x="0" width="14.4" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector3terminal" fill="none" x="0" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label3" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">4</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector4pin" fill="none" connectorName="5" x="0" width="14.4" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector4terminal" fill="none" x="0" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label4" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">5</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector5pin" fill="none" connectorName="6" x="0" width="14.4" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector5terminal" fill="none" x="0" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label5" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">6</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector6pin" fill="none" connectorName="7" x="0" width="14.4" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector6terminal" fill="none" x="0" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label6" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">7</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector7pin" fill="none" connectorName="8" x="0" width="14.4" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector7terminal" fill="none" x="0" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label7" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">8</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector8pin" fill="none" connectorName="9" x="0" width="14.4" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector8terminal" fill="none" x="0" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label8" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">9</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector9pin" fill="none" connectorName="10" x="0" width="14.4" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector9terminal" fill="none" x="0" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label9" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">10</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector10pin" fill="none" connectorName="11" x="0" width="14.4" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector10terminal" fill="none" x="0" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label10" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">11</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector11pin" fill="none" connectorName="12" x="0" width="14.4" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector11terminal" fill="none" x="0" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label11" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">12</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector12pin" fill="none" connectorName="13" x="0" width="14.4" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector12terminal" fill="none" x="0" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label12" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">13</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector13pin" fill="none" connectorName="14" x="0" width="14.4" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector13terminal" fill="none" x="0" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label13" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">14</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector14pin" fill="none" connectorName="15" x="0" width="14.4" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector14terminal" fill="none" x="0" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label14" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">15</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector15pin" fill="none" connectorName="16" x="0" width="14.4" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector15terminal" fill="none" x="0" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label15" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">16</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector16pin" fill="none" connectorName="17" x="0" width="14.4" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector16terminal" fill="none" x="0" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label16" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">17</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector17pin" fill="none" connectorName="18" x="0" width="14.4" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector17terminal" fill="none" x="0" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label17" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">18</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector18pin" fill="none" connectorName="19" x="0" width="14.4" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector18terminal" fill="none" x="0" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label18" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">19</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector19pin" fill="none" connectorName="20" x="0" width="14.4" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector19terminal" fill="none" x="0" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label19" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">20</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector20pin" fill="none" connectorName="21" x="0" width="14.4" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector20terminal" fill="none" x="0" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label20" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">21</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector21pin" fill="none" connectorName="22" x="0" width="14.4" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector21terminal" fill="none" x="0" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label21" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">22</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector22pin" fill="none" connectorName="23" x="0" width="14.4" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector22terminal" fill="none" x="0" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label22" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">23</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector23pin" fill="none" connectorName="24" x="0" width="14.4" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector23terminal" fill="none" x="0" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label23" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">24</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector24pin" fill="none" connectorName="25" x="0" width="14.4" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector24terminal" fill="none" x="0" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label24" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">25</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector25pin" fill="none" connectorName="26" x="0" width="14.4" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector25terminal" fill="none" x="0" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label25" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">26</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector26pin" fill="none" connectorName="27" x="0" width="14.4" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector26terminal" fill="none" x="0" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label26" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">27</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector27pin" fill="none" connectorName="28" x="0" width="14.4" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector27terminal" fill="none" x="0" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label27" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">28</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector28pin" fill="none" connectorName="29" x="0" width="14.4" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector28terminal" fill="none" x="0" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label28" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">29</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector29pin" fill="none" connectorName="30" x="0" width="14.4" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector29terminal" fill="none" x="0" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label29" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">30</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector30pin" fill="none" connectorName="31" x="0" width="14.4" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector30terminal" fill="none" x="0" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label30" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">31</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector31pin" fill="none" connectorName="32" x="0" width="14.4" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector31terminal" fill="none" x="0" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label31" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">32</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector32pin" fill="none" connectorName="33" x="0" width="14.4" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector32terminal" fill="none" x="0" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label32" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">33</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector33pin" fill="none" connectorName="34" x="0" width="14.4" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector33terminal" fill="none" x="0" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label33" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">34</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector34pin" fill="none" connectorName="35" x="0" width="14.4" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector34terminal" fill="none" x="0" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label34" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">35</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector35pin" fill="none" connectorName="36" x="0" width="14.4" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector35terminal" fill="none" x="0" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label35" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">36</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector36pin" fill="none" connectorName="37" x="0" width="14.4" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector36terminal" fill="none" x="0" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label36" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">37</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector37pin" fill="none" connectorName="38" x="0" width="14.4" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector37terminal" fill="none" x="0" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label37" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">38</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector38pin" fill="none" connectorName="39" x="0" width="14.4" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector38terminal" fill="none" x="0" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label38" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">39</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="0.349999" stroke-linecap="round" x2="14.4" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector39pin" fill="none" connectorName="40" x="0" width="14.4" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector39terminal" fill="none" x="0" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="start" font-size="3.5" id="label39" fill="#8c8c8c" font-family="'Droid Sans'" x="15.8" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="7.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">40</text>
+<line fill="none" y1="7.2" y2="7.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector79pin" fill="none" x="36" width="14.4" y="6.85" connectorname="80" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector79terminal" fill="none" x="50.4" width="0" y="6.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label79" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="7.89998" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="6.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">80</text>
+<line fill="none" y1="14.4" y2="14.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector78pin" fill="none" x="36" width="14.4" y="14.05" connectorname="79" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector78terminal" fill="none" x="50.4" width="0" y="14.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label78" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="15.1" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="13.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">79</text>
+<line fill="none" y1="21.6" y2="21.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector77pin" fill="none" x="36" width="14.4" y="21.25" connectorname="78" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector77terminal" fill="none" x="50.4" width="0" y="21.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label77" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="22.3" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="20.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">78</text>
+<line fill="none" y1="28.8" y2="28.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector76pin" fill="none" x="36" width="14.4" y="28.45" connectorname="77" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector76terminal" fill="none" x="50.4" width="0" y="28.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label76" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="29.5" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="27.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">77</text>
+<line fill="none" y1="36" y2="36" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector75pin" fill="none" x="36" width="14.4" y="35.65" connectorname="76" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector75terminal" fill="none" x="50.4" width="0" y="35.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label75" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="36.7" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="34.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">76</text>
+<line fill="none" y1="43.2" y2="43.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector74pin" fill="none" x="36" width="14.4" y="42.85" connectorname="75" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector74terminal" fill="none" x="50.4" width="0" y="42.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label74" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="43.9" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="42.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">75</text>
+<line fill="none" y1="50.4" y2="50.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector73pin" fill="none" x="36" width="14.4" y="50.05" connectorname="74" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector73terminal" fill="none" x="50.4" width="0" y="50.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label73" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="51.1" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="49.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">74</text>
+<line fill="none" y1="57.6" y2="57.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector72pin" fill="none" x="36" width="14.4" y="57.25" connectorname="73" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector72terminal" fill="none" x="50.4" width="0" y="57.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label72" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="58.3" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="56.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">73</text>
+<line fill="none" y1="64.8" y2="64.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector71pin" fill="none" x="36" width="14.4" y="64.45" connectorname="72" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector71terminal" fill="none" x="50.4" width="0" y="64.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label71" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="65.5" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="63.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">72</text>
+<line fill="none" y1="72" y2="72" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector70pin" fill="none" x="36" width="14.4" y="71.65" connectorname="71" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector70terminal" fill="none" x="50.4" width="0" y="71.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label70" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="72.6998" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="70.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">71</text>
+<line fill="none" y1="79.2" y2="79.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector69pin" fill="none" x="36" width="14.4" y="78.8501" connectorname="70" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector69terminal" fill="none" x="50.4" width="0" y="78.8501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label69" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="79.8998" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="78.1502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">70</text>
+<line fill="none" y1="86.4" y2="86.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector68pin" fill="none" x="36" width="14.4" y="86.0501" connectorname="69" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector68terminal" fill="none" x="50.4" width="0" y="86.0501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label68" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="87.0998" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="85.3502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">69</text>
+<line fill="none" y1="93.6" y2="93.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector67pin" fill="none" x="36" width="14.4" y="93.2501" connectorname="68" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector67terminal" fill="none" x="50.4" width="0" y="93.2501" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label67" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="94.2998" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="92.5502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">68</text>
+<line fill="none" y1="100.8" y2="100.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector66pin" fill="none" x="36" width="14.4" y="100.45" connectorname="67" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector66terminal" fill="none" x="50.4" width="0" y="100.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label66" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="101.5" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="99.7502" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">67</text>
+<line fill="none" y1="108" y2="108" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector65pin" fill="none" x="36" width="14.4" y="107.65" connectorname="66" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector65terminal" fill="none" x="50.4" width="0" y="107.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label65" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="108.7" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="106.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">66</text>
+<line fill="none" y1="115.2" y2="115.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector64pin" fill="none" x="36" width="14.4" y="114.85" connectorname="65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector64terminal" fill="none" x="50.4" width="0" y="114.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label64" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="115.9" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="114.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">65</text>
+<line fill="none" y1="122.4" y2="122.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector63pin" fill="none" x="36" width="14.4" y="122.05" connectorname="64" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector63terminal" fill="none" x="50.4" width="0" y="122.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label63" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="123.1" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="121.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">64</text>
+<line fill="none" y1="129.6" y2="129.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector62pin" fill="none" x="36" width="14.4" y="129.25" connectorname="63" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector62terminal" fill="none" x="50.4" width="0" y="129.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label62" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="130.3" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="128.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">63</text>
+<line fill="none" y1="136.8" y2="136.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector61pin" fill="none" x="36" width="14.4" y="136.45" connectorname="62" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector61terminal" fill="none" x="50.4" width="0" y="136.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label61" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="137.5" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="135.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">62</text>
+<line fill="none" y1="144" y2="144" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector60pin" fill="none" x="36" width="14.4" y="143.65" connectorname="61" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector60terminal" fill="none" x="50.4" width="0" y="143.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label60" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="144.7" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="142.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">61</text>
+<line fill="none" y1="151.2" y2="151.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector59pin" fill="none" x="36" width="14.4" y="150.85" connectorname="60" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector59terminal" fill="none" x="50.4" width="0" y="150.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label59" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="151.9" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="150.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">60</text>
+<line fill="none" y1="158.4" y2="158.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector58pin" fill="none" x="36" width="14.4" y="158.05" connectorname="59" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector58terminal" fill="none" x="50.4" width="0" y="158.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label58" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="159.1" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="157.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">59</text>
+<line fill="none" y1="165.6" y2="165.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector57pin" fill="none" x="36" width="14.4" y="165.25" connectorname="58" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector57terminal" fill="none" x="50.4" width="0" y="165.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label57" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="166.3" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="164.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">58</text>
+<line fill="none" y1="172.8" y2="172.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector56pin" fill="none" x="36" width="14.4" y="172.45" connectorname="57" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector56terminal" fill="none" x="50.4" width="0" y="172.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label56" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="173.5" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="171.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">57</text>
+<line fill="none" y1="180" y2="180" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector55pin" fill="none" x="36" width="14.4" y="179.65" connectorname="56" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector55terminal" fill="none" x="50.4" width="0" y="179.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label55" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="180.7" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="178.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">56</text>
+<line fill="none" y1="187.2" y2="187.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector54pin" fill="none" x="36" width="14.4" y="186.85" connectorname="55" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector54terminal" fill="none" x="50.4" width="0" y="186.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label54" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="187.9" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="186.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">55</text>
+<line fill="none" y1="194.4" y2="194.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector53pin" fill="none" x="36" width="14.4" y="194.05" connectorname="54" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector53terminal" fill="none" x="50.4" width="0" y="194.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label53" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="195.1" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="193.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">54</text>
+<line fill="none" y1="201.6" y2="201.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector52pin" fill="none" x="36" width="14.4" y="201.25" connectorname="53" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector52terminal" fill="none" x="50.4" width="0" y="201.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label52" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="202.3" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="200.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">53</text>
+<line fill="none" y1="208.8" y2="208.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector51pin" fill="none" x="36" width="14.4" y="208.45" connectorname="52" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector51terminal" fill="none" x="50.4" width="0" y="208.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label51" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="209.5" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="207.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">52</text>
+<line fill="none" y1="216" y2="216" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector50pin" fill="none" x="36" width="14.4" y="215.65" connectorname="51" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector50terminal" fill="none" x="50.4" width="0" y="215.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label50" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="216.7" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="214.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">51</text>
+<line fill="none" y1="223.2" y2="223.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector49pin" fill="none" x="36" width="14.4" y="222.85" connectorname="50" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector49terminal" fill="none" x="50.4" width="0" y="222.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label49" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="223.9" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="222.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">50</text>
+<line fill="none" y1="230.4" y2="230.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector48pin" fill="none" x="36" width="14.4" y="230.05" connectorname="49" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector48terminal" fill="none" x="50.4" width="0" y="230.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label48" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="231.1" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="229.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">49</text>
+<line fill="none" y1="237.6" y2="237.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector47pin" fill="none" x="36" width="14.4" y="237.25" connectorname="48" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector47terminal" fill="none" x="50.4" width="0" y="237.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label47" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="238.3" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="236.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">48</text>
+<line fill="none" y1="244.8" y2="244.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector46pin" fill="none" x="36" width="14.4" y="244.45" connectorname="47" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector46terminal" fill="none" x="50.4" width="0" y="244.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label46" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="245.5" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="243.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">47</text>
+<line fill="none" y1="252" y2="252" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector45pin" fill="none" x="36" width="14.4" y="251.65" connectorname="46" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector45terminal" fill="none" x="50.4" width="0" y="251.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label45" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="252.7" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="250.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">46</text>
+<line fill="none" y1="259.2" y2="259.2" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector44pin" fill="none" x="36" width="14.4" y="258.85" connectorname="45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector44terminal" fill="none" x="50.4" width="0" y="258.85" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label44" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="259.9" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="258.15" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">45</text>
+<line fill="none" y1="266.4" y2="266.4" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector43pin" fill="none" x="36" width="14.4" y="266.05" connectorname="44" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector43terminal" fill="none" x="50.4" width="0" y="266.05" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label43" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="267.1" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="265.35" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">44</text>
+<line fill="none" y1="273.6" y2="273.6" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector42pin" fill="none" x="36" width="14.4" y="273.25" connectorname="43" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector42terminal" fill="none" x="50.4" width="0" y="273.25" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label42" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="274.3" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="272.55" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">43</text>
+<line fill="none" y1="280.8" y2="280.8" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector41pin" fill="none" x="36" width="14.4" y="280.45" connectorname="42" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector41terminal" fill="none" x="50.4" width="0" y="280.45" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label41" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="281.5" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="279.75" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">42</text>
+<line fill="none" y1="288" y2="288" stroke-linejoin="round" stroke-width="0.699998" x1="35.65" stroke-linecap="round" x2="50.05" stroke="#787878" xmlns="http://www.w3.org/2000/svg"/>
+<rect height="0.699998" id="connector40pin" fill="none" x="36" width="14.4" y="287.65" connectorname="41" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<g height="0.699998" id="connector40terminal" fill="none" x="50.4" width="0" y="287.65" stroke-width="0" xmlns="http://www.w3.org/2000/svg"/>
+<text text-anchor="end" font-size="3.5" id="label40" fill="#8c8c8c" font-family="'Droid Sans'" x="34.6" y="288.7" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+<text text-anchor="middle" font-size="2.5" fill="#8c8c8c" font-family="Droid Sans" x="43.2" y="286.95" stroke-width="0" class="text" stroke="none" xmlns="http://www.w3.org/2000/svg">41</text>
+</g>
+</g></svg>

--- a/svg/core/schematic/svg.schematic.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_schematic.svg
+++ b/svg/core/schematic/svg.schematic.tilt-switch-sw200d_00e7c628c2472b6ab96c3704e810bb8c_1_schematic.svg
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<!-- Created with Fritzing (http://www.fritzing.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" x="0in" width="0.409722in" baseProfile="tiny" y="0in" height="0.068in"  version="1.2" viewBox="0 0 10.4069 1.7272">
+    <desc >
+        <referenceFile >sparkfun-electromechanical_switch-momentary-2_schematic.svg</referenceFile>
+    </desc>
+    <g  id="schematic" gorn="0.1">
+        <line class="other"  y1="1.397" y2="1.397" x1="7.10847" stroke-width="0.254" x2="7.74347" stroke="#000000" stroke-linecap="round"/>
+        <line class="other"  y1="1.397" y2="0.127" x1="2.66347" stroke-width="0.254" x2="7.10847" stroke="#000000" stroke-linecap="round"/>
+        <circle class="other" fill="none"  r="0.127" cx="2.66347" cy="1.397" stroke-width="0.4064" stroke="#000000"/>
+        <circle class="other" fill="none"  r="0.127" cx="7.74347" cy="1.397" stroke-width="0.4064" stroke="#000000"/>
+        <line class="pin"  id="connector0pin" y1="1.397" y2="1.397" connectorname="1" x1="0.123472" stroke-width="0.246944" x2="2.66347" gorn="0.1.4" stroke="#787878" stroke-linecap="round"/>
+        <rect x="0.123472" width="0.0001" y="1.397" height="0.0001" class="terminal" fill="none"  id="connector0terminal" stroke-width="0" gorn="0.1.5" stroke="none"/>
+        <text x="1.39347" font-size="0.881944" y="1.02658" class="text" fill="#8c8c8c" font-family="'Droid Sans'"  text-anchor="middle" stroke-width="0" stroke="none">1</text>
+        <line class="pin"  id="connector2pin" y1="1.397" y2="1.397" connectorname="2" x1="10.2835" stroke-width="0.246944" x2="7.74347" gorn="0.1.7" stroke="#787878" stroke-linecap="round"/>
+        <rect x="10.2835" width="0.0001" y="1.397" height="0.0001" class="terminal" fill="none"  id="connector2terminal" stroke-width="0" gorn="0.1.8" stroke="none"/>
+        <text x="9.01347" font-size="0.881944" y="1.02658" class="text" fill="#8c8c8c" font-family="'Droid Sans'"  text-anchor="middle" stroke-width="0" stroke="none">3</text>
+    </g>
+</svg>


### PR DESCRIPTION
I have added a [note in the Fritzing forum too](http://forum.fritzing.org/t/sw-200d-tilt-switch-new-custom-part/1073)

**Manufacturer and name:** YUSAN, tilt switch SW-200D

**Original photo**

![sw-200d](https://cloud.githubusercontent.com/assets/413879/14760158/a5b78482-096e-11e6-90f5-6e45e06bb2a0.jpg)

**Working example with a breadboard circuit**

![image](https://cloud.githubusercontent.com/assets/413879/14760193/49f39e50-096f-11e6-8da7-a7ce556435bc.png)


**Breadboard photo**

<img width="959" alt="sw-200d-breadboard" src="https://cloud.githubusercontent.com/assets/413879/14760162/c1da9258-096e-11e6-8f21-ba3f98cabe92.png">

**Icon pic**

<img width="959" alt="sw-200d-icon" src="https://cloud.githubusercontent.com/assets/413879/14760163/c9120236-096e-11e6-959a-eedabc211551.png">

**PCB pic**

<img width="959" alt="sw-200d-pcb" src="https://cloud.githubusercontent.com/assets/413879/14760164/d155b9b0-096e-11e6-9337-8f29ead06787.png">

**Schematic pic**:

<img width="959" alt="sw-200d-schematic" src="https://cloud.githubusercontent.com/assets/413879/14760166/d872b3c4-096e-11e6-9601-e54a003690fa.png">


