### PR TITLE
Renamed the PCB SVG for the YC164 to 0603x4.

### DIFF
--- a/core/smd-YC164.fzp
+++ b/core/smd-YC164.fzp
@@ -29,7 +29,7 @@
 </layers>
 </schematicView>
 <pcbView>
-<layers image='pcb/smd-YC164_pcb.svg'>
+<layers image='pcb/SMD_0603x4.svg'>
 <layer layerId='copper1'/>
 <layer layerId='silkscreen'/>
 </layers>

--- a/svg/core/pcb/SMD_0603x4.svg
+++ b/svg/core/pcb/SMD_0603x4.svg
@@ -16,6 +16,5 @@
 <g id="silkscreen">
 	<line fill="none" stroke="#000000" stroke-width="0.5" stroke-miterlimit="10" x1="0.406" y1="5.53" x2="0.406" y2="0.406"/>
 	<line fill="none" stroke="#000000" stroke-width="0.5" stroke-miterlimit="10" x1="11.546" y1="0.406" x2="11.546" y2="5.53"/>
-	<text transform="matrix(1 0 0 1 2.2644 3.7544)" font-family="'OCRAStd'" font-size="2">YC164</text>
 </g>
 </svg>


### PR DESCRIPTION
Also removed the "YC164" text from the pcb layout.  This is in support of
the creation of more parts in this form factor.