### PR TITLE
Added JST-VH 3 pin male header and female connector types

### DIFF
--- a/bins/core.fzb
+++ b/bins/core.fzb
@@ -899,6 +899,22 @@
         </views>
       </instance>
   
+      <instance moduleIdRef="JST-B3P-VH" modelIndex="46" path="JST-B3P-VH.fzp">
+        <views>
+          <iconView layer="icon">
+            <geometry z="-1" x="-1" y="-1"></geometry>
+          </iconView>
+        </views>
+      </instance>
+  
+      <instance moduleIdRef="JST-VHR-3N" modelIndex="46" path="JST-VHR-3N.fzp">
+        <views>
+          <iconView layer="icon">
+            <geometry z="-1" x="-1" y="-1"></geometry>
+          </iconView>
+        </views>
+      </instance>
+  
       <instance moduleIdRef="screw_terminal_2_3.5mm" modelIndex="46" path="screw_terminal_2_3.5mm.fzp">
         <views>
           <iconView layer="icon">

--- a/bins/more/dagu.fzb
+++ b/bins/more/dagu.fzb
@@ -63,5 +63,22 @@
             </views>
         </instance>
 
+      <instance moduleIdRef="JST-B3P-VH" modelIndex="" path="JST-B3P-VH.fzp">
+        <views>
+          <iconView layer="icon">
+            <geometry z="-1" x="-1" y="-1"></geometry>
+          </iconView>
+        </views>
+      </instance>
+  
+      <instance moduleIdRef="JST-VHR-3N" modelIndex="" path="JST-VHR-3N.fzp">
+        <views>
+          <iconView layer="icon">
+            <geometry z="-1" x="-1" y="-1"></geometry>
+          </iconView>
+        </views>
+      </instance>
+  
+
    </instances>
 </module>

--- a/core/JST-B3P-VH.fzp
+++ b/core/JST-B3P-VH.fzp
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<module moduleId="JST-B3P-VH" referenceFile="generic_male_pin_header_3_0.156in.fzp" fritzingVersion="0.2.2.b.03.04.2550">
+ <version>4</version>
+ <author>Stephen G. Parry</author>
+ <title>JST-B3P-VH</title>
+ <label>J</label>
+ <date>Thu Jun 16 2016</date>
+ <tags/>
+ <properties>
+  <property name="family">JST VH Pin Header</property>
+  <property name="variant">- Male 3 pin header</property>
+  <property name="hole size"></property>
+  <property name="part number">JST-B3P-VH</property>
+  <property name="Pin Spacing">0.156in (3.96mm)</property>
+  <property name="Form">♂ (male)</property>
+  <property name="Pins">3</property>
+  <property name="layer"></property>
+  <property name="Position"></property>
+  <property name="Row">single</property>
+  <property name="package">THT</property>
+ </properties>
+ <description>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">JST-B3P-VH&lt;/span>&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">Male 3 pin header from JST VH series.&lt;/span>&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">The female partner connector (JST-VHR-3N) to this is used on Dagu motors in their robots. This part is not breadboard or stripboard friendly - the pin spacings are not properly compatible. However, you can make the part fit by drilling between the tracks for the outer connectors and soldering a trace across them. This can be represented in Frtizing using additional wires. This has the secondary benefit of increasing current carrying capacity.&lt;/span>&lt;/p>
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Oxygen-Sans'; font-size:10pt;">&lt;br />&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">When plugging the female connector onto this, ensure that the correct connectors on the female have located.&lt;/span>&lt;/p>
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Oxygen-Sans'; font-size:10pt;">&lt;br />&lt;/p>&lt;/body>&lt;/html></description>
+ <views>
+  <iconView>
+   <layers image="icon/JST-B3P-VH_icon.svg">
+    <layer layerId="icon"/>
+   </layers>
+  </iconView>
+  <breadboardView>
+   <layers image="breadboard/JST-B3P-VH_breadboard.svg">
+    <layer layerId="breadboard"/>
+   </layers>
+  </breadboardView>
+  <schematicView fliphorizontal="true">
+   <layers image="schematic/JST-B3P-VH_schematic.svg">
+    <layer layerId="schematic"/>
+   </layers>
+  </schematicView>
+  <pcbView>
+   <layers image="pcb/JST-B3P-VH_pcb.svg">
+    <layer layerId="copper0"/>
+    <layer layerId="silkscreen"/>
+    <layer layerId="copper1"/>
+   </layers>
+  </pcbView>
+ </views>
+ <connectors>
+  <connector name="pin2" id="connector0" type="male">
+   <description>pin 2</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector1pin" layer="breadboard" terminalId="connector1terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector1pin" layer="schematic" terminalId="connector1terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector1pin" layer="copper0"/>
+     <p svgId="connector1pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin1" id="connector1" type="male">
+   <description>pin 1</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector0pin" layer="breadboard" terminalId="connector0terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector0pin" layer="schematic" terminalId="connector0terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector0pin" layer="copper0"/>
+     <p svgId="connector0pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin3" id="connector2" type="male">
+   <description>pin 3</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector2pin" layer="breadboard" terminalId="connector2terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector2pin" layer="schematic" terminalId="connector2terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector2pin" layer="copper0"/>
+     <p svgId="connector2pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+ </connectors>
+</module>

--- a/core/JST-VHR-3N.fzp
+++ b/core/JST-VHR-3N.fzp
@@ -1,0 +1,164 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<module moduleId="JST-VHR-3N" referenceFile="generic_male_pin_header_3_0.156in.fzp" fritzingVersion="0.2.2.b.03.04.2550">
+ <version>4</version>
+ <author>Stephen G. Parry</author>
+ <title>JST-VHR-3N</title>
+ <label>J</label>
+ <date>Thu Jun 16 2016</date>
+ <tags>
+  <tag>VH</tag>
+  <tag>JST</tag>
+ </tags>
+ <properties>
+  <property name="family">JST VH Pin Header</property>
+  <property name="variant">- Female 3 pin connector</property>
+  <property name="hole size"></property>
+  <property name="part number">JST-VHR-3N</property>
+  <property name="Pin Spacing">0.156in (3.96mm)</property>
+  <property name="Form">♀ (female)</property>
+  <property name="Pins">3</property>
+  <property name="layer"></property>
+  <property name="Position"></property>
+  <property name="Row">single</property>
+  <property name="package">THT</property>
+ </properties>
+ <description>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">JST-VHR-3N&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">Female 3 pin connector receptacle from JST VH series&lt;/span>&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">This plug is used on Dagu motors in their robots. It is designed to mate with the JST-B3P-VH male header.&lt;/span>&lt;/p>
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">&lt;span style=" font-family:'Oxygen-Sans'; font-size:10pt;">Note that because of the difference in alignment and spacing, the rear connection and front connection holes are represented as different connectors, with an internal connection between. When plugging onto the male header, ensure that the correct connectors have located.&lt;/span>&lt;/p>
+&lt;p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Oxygen-Sans'; font-size:10pt;">&lt;br />&lt;/p>&lt;/body>&lt;/html></description>
+ <views>
+  <iconView>
+   <layers image="icon/JST-VHR-3N_icon.svg">
+    <layer layerId="icon"/>
+   </layers>
+  </iconView>
+  <breadboardView>
+   <layers image="breadboard/JST-VHR-3N_breadboard.svg">
+    <layer layerId="breadboard"/>
+   </layers>
+  </breadboardView>
+  <schematicView fliphorizontal="true">
+   <layers image="schematic/JST-VHR-3N_schematic.svg">
+    <layer layerId="schematic"/>
+   </layers>
+  </schematicView>
+  <pcbView>
+   <layers image="pcb/JST-VHR-3N_pcb.svg">
+    <layer layerId="copper0"/>
+    <layer layerId="silkscreen"/>
+    <layer layerId="copper1"/>
+   </layers>
+  </pcbView>
+ </views>
+ <connectors>
+  <connector name="pin1" id="connector1" type="male">
+   <description>pin 1</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector0pin" layer="breadboard" terminalId="connector0terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector0pin" layer="schematic" terminalId="connector0terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector0pin" layer="copper0"/>
+     <p svgId="connector0pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin2" id="connector0" type="male">
+   <description>pin 2</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector1pin" layer="breadboard" terminalId="connector1terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector1pin" layer="schematic" terminalId="connector1terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector1pin" layer="copper0"/>
+     <p svgId="connector1pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin3" id="connector2" type="male">
+   <description>pin 3</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector2pin" layer="breadboard" terminalId="connector2terminal"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector2pin" layer="schematic" terminalId="connector2terminal"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector2pin" layer="copper0"/>
+     <p svgId="connector2pin" layer="copper1"/>
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin 4" id="connector4" type="female">
+   <description>pin 4</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector3pin" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector3pin" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector3pin" layer="copper0" hybrid="yes" />
+     <p svgId="connector3pin" layer="copper1" hybrid="yes" />
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin 5" id="connector3" type="female">
+   <description>pin 5</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector4pin" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector4pin" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector4pin" layer="copper0" hybrid="yes" />
+     <p svgId="connector4pin" layer="copper1" hybrid="yes" />
+    </pcbView>
+   </views>
+  </connector>
+  <connector name="pin 6" id="connector5" type="female">
+   <description>pin 6</description>
+   <views>
+    <breadboardView>
+     <p svgId="connector5pin" layer="breadboard"/>
+    </breadboardView>
+    <schematicView>
+     <p svgId="connector5pin" layer="schematic"/>
+    </schematicView>
+    <pcbView>
+     <p svgId="connector5pin" layer="copper0" hybrid="yes" />
+     <p svgId="connector5pin" layer="copper1" hybrid="yes" />
+    </pcbView>
+   </views>
+  </connector>
+ </connectors>
+ <buses>
+  <bus id="internal1">
+   <nodeMember connectorId="connector0"/>
+   <nodeMember connectorId="connector3"/>
+  </bus>
+  <bus id="internal2">
+   <nodeMember connectorId="connector1"/>
+   <nodeMember connectorId="connector4"/>
+  </bus>
+  <bus id="internal3">
+   <nodeMember connectorId="connector2"/>
+   <nodeMember connectorId="connector5"/>
+  </bus>
+ </buses>
+</module>

--- a/core/JST-VHR-3N.fzp
+++ b/core/JST-VHR-3N.fzp
@@ -111,8 +111,7 @@ p, li { white-space: pre-wrap; }
      <p svgId="connector3pin" layer="schematic"/>
     </schematicView>
     <pcbView>
-     <p svgId="connector3pin" layer="copper0" hybrid="yes" />
-     <p svgId="connector3pin" layer="copper1" hybrid="yes" />
+     <p svgId="connector3pin" layer="unknown" hybrid="yes" />
     </pcbView>
    </views>
   </connector>
@@ -126,8 +125,7 @@ p, li { white-space: pre-wrap; }
      <p svgId="connector4pin" layer="schematic"/>
     </schematicView>
     <pcbView>
-     <p svgId="connector4pin" layer="copper0" hybrid="yes" />
-     <p svgId="connector4pin" layer="copper1" hybrid="yes" />
+     <p svgId="connector4pin" layer="unknown" hybrid="yes" />
     </pcbView>
    </views>
   </connector>
@@ -141,8 +139,7 @@ p, li { white-space: pre-wrap; }
      <p svgId="connector5pin" layer="schematic"/>
     </schematicView>
     <pcbView>
-     <p svgId="connector5pin" layer="copper0" hybrid="yes" />
-     <p svgId="connector5pin" layer="copper1" hybrid="yes" />
+     <p svgId="connector5pin" layer="unknown" hybrid="yes" />
     </pcbView>
    </views>
   </connector>

--- a/svg/core/breadboard/JST-B3P-VH_breadboard.svg
+++ b/svg/core/breadboard/JST-B3P-VH_breadboard.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 41.881888 37.205752"
+   height="0.41339725in"
+   width="0.46535432in">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(19.38084,25.687731)"
+     id="breadboard">
+    <g
+       style="opacity:1"
+       transform="translate(-106.65418,-99.447685)"
+       id="g5474" />
+    <rect
+       ry="2.1259844"
+       rx="2.1259844"
+       y="-12.576468"
+       x="-19.38084"
+       height="24.094488"
+       width="41.881889"
+       id="rect4136"
+       style="opacity:1;fill:#dcdcdc;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       style="opacity:1;fill:#b7b7b7;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.275968,-14.083204 -35.431637,0 0,1.505859 35.431637,0 0,-1.505859 z"
+       id="path4286" />
+    <path
+       style="opacity:1;fill:#d3d3d3;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19.275968,-17.094923 -35.431637,0 0,3.011719 35.431637,0 0,-3.011719 z"
+       id="path4284" />
+    <path
+       style="opacity:1;fill:#dddddd;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m -16.155669,-18.600782 0,1.505859 35.431637,0 0,-1.505859 -35.431637,0 z"
+       id="rect4140" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5095358"
+       x="-14.491078"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector0terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector0pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-14.491078"
+       y="-7.5095358"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <g
+       style="opacity:1"
+       transform="translate(-105.09513,-104.93867)"
+       id="g4830">
+      <rect
+         ry="0.35433072"
+         rx="0.35433072"
+         y="98.437843"
+         x="91.612839"
+         height="2.019685"
+         width="2.019685"
+         id="rect4154"
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 94.464554,101.29045 -1.009766,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.175781,0.17773 l -1.310547,0 c -0.09815,0 -0.113405,-0.1134 -0.177734,-0.17773 l -1.009766,1.00976 c 0.06437,0.0642 0.07931,0.17774 0.177735,0.17774 l 3.330078,0 c 0.09815,0 0.11194,-0.11389 0.175781,-0.17774 z"
+         id="path4217" />
+      <path
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 93.456742,98.614675 c 0.06384,0.0638 0.175781,0.0796 0.175781,0.17774 l 0,1.310535 c 0,0.0984 -0.113583,0.11337 -0.177735,0.17774 l 1.009766,1.00976 c 0.06384,-0.0638 0.177734,-0.0776 0.177734,-0.17578 l 0,-3.332025 c 0,-0.0982 -0.113893,-0.11194 -0.177734,-0.17578 l -1.007812,1.00781 z"
+         id="path4222" />
+      <path
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 90.78096,97.606865 c -0.06402,0.0638 -0.177734,0.0779 -0.177734,0.17578 l 0,3.332025 c 0,0.0979 0.113716,0.11198 0.177734,0.17578 l 1.009766,-1.00976 c -0.06433,-0.0643 -0.177735,-0.0796 -0.177734,-0.17774 l 0,-1.310535 c 0,-0.0979 0.113716,-0.11198 0.177734,-0.17578 l -1.009766,-1.00977 z"
+         id="path4220" />
+      <path
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 90.78096,97.606865 1.009766,1.00977 c 0.06437,-0.0642 0.07931,-0.17774 0.177734,-0.17774 l 1.310547,0 c 0.09815,0 0.113893,0.11194 0.177735,0.17578 l 1.007812,-1.00781 c -0.06384,-0.0638 -0.07763,-0.17773 -0.175781,-0.17773 l -3.330078,0 c -0.09842,0 -0.113364,0.11358 -0.177735,0.17773 z"
+         id="rect4159" />
+    </g>
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector1terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-0.45957753"
+       y="-7.5095358"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5095358"
+       x="-0.45957753"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector1pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       style="opacity:1"
+       transform="translate(-105.09539,-104.93867)"
+       id="g4843">
+      <rect
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect5450"
+         width="2.019685"
+         height="2.019685"
+         x="105.64434"
+         y="98.437843"
+         rx="0.35433072"
+         ry="0.35433072" />
+      <path
+         id="path5452"
+         d="m 108.49605,101.29045 -1.00976,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.17578,0.17773 l -1.31055,0 c -0.0982,0 -0.11341,-0.1134 -0.17774,-0.17773 l -1.00976,1.00976 c 0.0644,0.0642 0.0793,0.17774 0.17773,0.17774 l 3.33008,0 c 0.0982,0 0.11194,-0.11389 0.17578,-0.17774 z"
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5454"
+         d="m 107.48824,98.614675 c 0.0638,0.0638 0.17578,0.0796 0.17578,0.17774 l 0,1.310535 c 0,0.0984 -0.11358,0.11337 -0.17773,0.17774 l 1.00976,1.00976 c 0.0638,-0.0638 0.17774,-0.0776 0.17774,-0.17578 l 0,-3.332025 c 0,-0.0982 -0.1139,-0.11194 -0.17774,-0.17578 l -1.00781,1.00781 z"
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5456"
+         d="m 104.81246,97.606865 c -0.064,0.0638 -0.17774,0.0779 -0.17774,0.17578 l 0,3.332025 c 0,0.0979 0.11372,0.11198 0.17774,0.17578 l 1.00976,-1.00976 c -0.0643,-0.0643 -0.17773,-0.0796 -0.17773,-0.17774 l 0,-1.310535 c 0,-0.0979 0.11372,-0.11198 0.17773,-0.17578 l -1.00976,-1.00977 z"
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5458"
+         d="m 104.81246,97.606865 1.00976,1.00977 c 0.0644,-0.0642 0.0793,-0.17774 0.17774,-0.17774 l 1.31054,0 c 0.0981,0 0.1139,0.11194 0.17774,0.17578 l 1.00781,-1.00781 c -0.0638,-0.0638 -0.0776,-0.17773 -0.17578,-0.17773 l -3.33008,0 c -0.0984,0 -0.11336,0.11358 -0.17773,0.17773 z"
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5106726"
+       x="13.570865"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector2terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector2pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="13.570865"
+       y="-7.5106726"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <g
+       style="opacity:1"
+       transform="translate(-105.09513,-104.93867)"
+       id="g4856">
+      <rect
+         ry="0.35433072"
+         rx="0.35433072"
+         y="98.436707"
+         x="119.67478"
+         height="2.019685"
+         width="2.019685"
+         id="rect5464"
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 122.5265,101.28931 -1.00977,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.17578,0.17773 l -1.31055,0 c -0.0982,0 -0.1134,-0.1134 -0.17773,-0.17773 l -1.00977,1.00976 c 0.0644,0.0642 0.0793,0.17774 0.17774,0.17774 l 3.33008,0 c 0.0982,0 0.11194,-0.11389 0.17578,-0.17774 z"
+         id="path5466" />
+      <path
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 121.51869,98.613538 c 0.0638,0.0638 0.17578,0.0796 0.17578,0.17774 l 0,1.310532 c 0,0.0984 -0.11359,0.11337 -0.17774,0.17774 l 1.00977,1.00976 c 0.0638,-0.0638 0.17773,-0.0776 0.17773,-0.17578 l 0,-3.332022 c 0,-0.0982 -0.11389,-0.11194 -0.17773,-0.17578 l -1.00781,1.00781 z"
+         id="path5468" />
+      <path
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 118.8429,97.605728 c -0.064,0.0638 -0.17773,0.0779 -0.17773,0.17578 l 0,3.332022 c 0,0.0979 0.11371,0.11198 0.17773,0.17578 l 1.00977,-1.00976 c -0.0643,-0.0643 -0.17774,-0.0796 -0.17774,-0.17774 l 0,-1.310532 c 0,-0.0979 0.11372,-0.11198 0.17774,-0.17578 l -1.00977,-1.00977 z"
+         id="path5470" />
+      <path
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 118.8429,97.605728 1.00977,1.00977 c 0.0644,-0.0642 0.0793,-0.17774 0.17773,-0.17774 l 1.31055,0 c 0.0981,0 0.11389,0.11194 0.17773,0.17578 l 1.00782,-1.00781 c -0.0638,-0.0638 -0.0776,-0.17773 -0.17578,-0.17773 l -3.33008,0 c -0.0984,0 -0.11337,0.11358 -0.17774,0.17773 z"
+         id="path5472" />
+    </g>
+  </g>
+</svg>

--- a/svg/core/breadboard/JST-VHR-3N_breadboard.svg
+++ b/svg/core/breadboard/JST-VHR-3N_breadboard.svg
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 41.882811 37.205755"
+   height="0.41339728in"
+   width="0.46536458in">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(19.380846,25.688197)"
+     id="breadboard">
+    <path
+       id="bottomface"
+       d="m -19.380846,-17.095724 0,14.6171877 0,7.972656 c 0,1.177795 0.949158,2.125 2.126953,2.125 l 37.628906,0 c 1.177796,0 2.126953,-0.947205 2.126953,-2.125 l 0,-7.972656 0,-7.9726567 0,-6.644531 -3.226562,0 0,4.517578 -35.431641,0 0,-4.517578 -3.224609,0 z"
+       style="opacity:1;fill:#cfcfcf;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5103364"
+       x="-14.491083"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector0terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector0pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-14.491083"
+       y="-7.5103364"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector1terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-0.45958096"
+       y="-7.5103364"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5103364"
+       x="-0.45958096"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector1pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector2pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="13.57086"
+       y="-7.5114732"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-7.5114732"
+       x="13.57086"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector2terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       ry="2.1259844"
+       rx="2.1259844"
+       y="-12.577269"
+       x="-19.380846"
+       height="20.19685"
+       width="41.881889"
+       id="insideface"
+       style="opacity:1;fill:#666666;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <path
+       id="topface"
+       d="m -17.253893,-12.578146 c -1.177795,0 -2.126953,0.949158 -2.126953,2.126953 l 0,15.9453127 c 0,0.940884 0.609257,1.726314 1.453125,2.007813 l 0,1.888672 c 0,1.1777943 0.947205,2.1269533 2.125,2.1269533 l 34.724609,0 c 1.177796,0 2.126954,-0.949159 2.126954,-2.1269533 l 0,-1.888672 c 0.843867,-0.281499 1.453124,-1.066929 1.453124,-2.007813 l 0,-15.9453127 c 0,-1.177795 -0.949157,-2.126953 -2.126953,-2.126953 l -37.628906,0 z m 0,2.8359377 11.125,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.904297,0 0,-14.527344 z m 13.251953,0 11.125,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.904297,0 0,-14.527344 z m 13.251953,0 11.125,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.904297,0 0,-14.527344 z"
+       style="opacity:1;fill:#e4e4e4;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-3.0114732"
+       x="-13.71108"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector3pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector3terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-13.71108"
+       y="-3.0114732"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector4pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-0.45912319"
+       y="-3.0114732"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-3.0114732"
+       x="-0.45912319"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector4terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector5pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="12.792827"
+       y="-3.0114732"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-3.0114732"
+       x="12.792827"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector5terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       transform="translate(1.55905,-5.4917893)"
+       style="opacity:1"
+       id="retainingclip">
+      <rect
+         style="fill:#e7e7e7;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4806"
+         width="27.850393"
+         height="7.0866141"
+         x="-13.924105"
+         y="-20.196407" />
+      <rect
+         style="fill:#dbdbdb;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4808"
+         width="4.2519689"
+         height="6.0234356"
+         x="-13.924105"
+         y="-13.109793" />
+      <rect
+         y="-13.109793"
+         x="9.6743202"
+         height="6.0234356"
+         width="4.2519689"
+         id="rect4810"
+         style="fill:#dbdbdb;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         y="-8.2910814"
+         x="-13.924105"
+         height="1.2047244"
+         width="4.2519689"
+         id="rect4812"
+         style="fill:#e2e2e2;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#e2e2e2;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4814"
+         width="4.2519689"
+         height="1.2047244"
+         x="9.6743202"
+         y="-8.2910814" />
+    </g>
+    <g
+       style="opacity:1"
+       transform="translate(32.208615,-10.171112)"
+       id="g4862">
+      <rect
+         ry="2.1259799"
+         rx="2.1259799"
+         y="0.9602918"
+         x="-49.21497"
+         height="13.464567"
+         width="10.629921"
+         id="rect4854"
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="1.8105338"
+         x="-47.957333"
+         height="11.764083"
+         width="8.1146507"
+         id="rect4856"
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4858"
+         width="10.629921"
+         height="8.0190973"
+         x="-49.21497"
+         y="6.4057612"
+         rx="2.1259799"
+         ry="1.2661706" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4860"
+         width="8.1146507"
+         height="5.8820415"
+         x="-47.957333"
+         y="7.4742889"
+         rx="1.32838" />
+      <rect
+         ry="1.32838"
+         rx="1.32838"
+         y="1.8105336"
+         x="-47.957333"
+         height="4.5952277"
+         width="8.114646"
+         id="rect4892"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         ry="0.70866144"
+         rx="0.70866144"
+         y="3.3223116"
+         x="-47.001991"
+         height="1.571671"
+         width="6.2039642"
+         id="rect4888"
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    </g>
+    <g
+       style="opacity:1"
+       transform="translate(58.712523,-10.171112)"
+       id="g5363">
+      <rect
+         ry="2.1259799"
+         rx="2.1259799"
+         y="0.9602918"
+         x="-49.21497"
+         height="13.464567"
+         width="10.629921"
+         id="rect5365"
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="1.8105338"
+         x="-47.957333"
+         height="11.764083"
+         width="8.1146507"
+         id="rect5367"
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5369"
+         width="10.629921"
+         height="8.0190973"
+         x="-49.21497"
+         y="6.4057612"
+         rx="2.1259799"
+         ry="1.2661706" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5371"
+         width="8.1146507"
+         height="5.8820415"
+         x="-47.957333"
+         y="7.4742889"
+         rx="1.32838" />
+      <rect
+         ry="1.32838"
+         rx="1.32838"
+         y="1.8105336"
+         x="-47.957333"
+         height="4.5952277"
+         width="8.114646"
+         id="rect5373"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         ry="0.70866144"
+         rx="0.70866144"
+         y="3.3223116"
+         x="-47.001991"
+         height="1.571671"
+         width="6.2039642"
+         id="rect5375"
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    </g>
+    <g
+       id="g5349"
+       transform="translate(45.460567,-10.171112)"
+       style="opacity:1">
+      <rect
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5351"
+         width="10.629921"
+         height="13.464567"
+         x="-49.21497"
+         y="0.9602918"
+         rx="2.1259799"
+         ry="2.1259799" />
+      <rect
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5353"
+         width="8.1146507"
+         height="11.764083"
+         x="-47.957333"
+         y="1.8105338"
+         rx="1.32838" />
+      <rect
+         ry="1.2661706"
+         rx="2.1259799"
+         y="6.4057612"
+         x="-49.21497"
+         height="8.0190973"
+         width="10.629921"
+         id="rect5355"
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="7.4742889"
+         x="-47.957333"
+         height="5.8820415"
+         width="8.1146507"
+         id="rect5357"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5359"
+         width="8.114646"
+         height="4.5952277"
+         x="-47.957333"
+         y="1.8105336"
+         rx="1.32838"
+         ry="1.32838" />
+      <rect
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5361"
+         width="6.2039642"
+         height="1.571671"
+         x="-47.001991"
+         y="3.3223116"
+         rx="0.70866144"
+         ry="0.70866144" />
+    </g>
+  </g>
+</svg>

--- a/svg/core/icon/JST-B3P-VH_icon.svg
+++ b/svg/core/icon/JST-B3P-VH_icon.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 41.881888 30.118803"
+   height="8.5001955mm"
+   width="11.82mm">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(20.939896,13.109794)"
+     id="icon">
+    <rect
+       ry="2.1259844"
+       rx="2.1259844"
+       y="-7.0854797"
+       x="-20.939896"
+       height="24.094488"
+       width="41.881889"
+       id="rect4136"
+       style="opacity:1;fill:#dcdcdc;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       style="opacity:1"
+       transform="translate(-106.65418,-99.447685)"
+       id="g5474">
+      <path
+         style="opacity:1;fill:#b7b7b7;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 124.37109,90.855469 -35.431637,0 0,1.505859 35.431637,0 0,-1.505859 z"
+         id="path4286" />
+      <path
+         style="opacity:1;fill:#d3d3d3;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 124.37109,87.84375 -35.431637,0 0,3.011719 35.431637,0 0,-3.011719 z"
+         id="path4284" />
+      <path
+         style="opacity:1;fill:#dddddd;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 88.939453,86.337891 0,1.505859 35.431637,0 0,-1.505859 -35.431637,0 z"
+         id="rect4140" />
+    </g>
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0185471"
+       x="-16.050133"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector0terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector0pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-16.050133"
+       y="-2.0185471"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <g
+       style="opacity:1"
+       transform="translate(-106.65418,-99.447685)"
+       id="g4830">
+      <rect
+         ry="0.35433072"
+         rx="0.35433072"
+         y="98.437843"
+         x="91.612839"
+         height="2.019685"
+         width="2.019685"
+         id="rect4154"
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 94.464554,101.29045 -1.009766,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.175781,0.17773 l -1.310547,0 c -0.09815,0 -0.113405,-0.1134 -0.177734,-0.17773 l -1.009766,1.00976 c 0.06437,0.0642 0.07931,0.17774 0.177735,0.17774 l 3.330078,0 c 0.09815,0 0.11194,-0.11389 0.175781,-0.17774 z"
+         id="path4217" />
+      <path
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 93.456742,98.614675 c 0.06384,0.0638 0.175781,0.0796 0.175781,0.17774 l 0,1.310535 c 0,0.0984 -0.113583,0.11337 -0.177735,0.17774 l 1.009766,1.00976 c 0.06384,-0.0638 0.177734,-0.0776 0.177734,-0.17578 l 0,-3.332025 c 0,-0.0982 -0.113893,-0.11194 -0.177734,-0.17578 l -1.007812,1.00781 z"
+         id="path4222" />
+      <path
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 90.78096,97.606865 c -0.06402,0.0638 -0.177734,0.0779 -0.177734,0.17578 l 0,3.332025 c 0,0.0979 0.113716,0.11198 0.177734,0.17578 l 1.009766,-1.00976 c -0.06433,-0.0643 -0.177735,-0.0796 -0.177734,-0.17774 l 0,-1.310535 c 0,-0.0979 0.113716,-0.11198 0.177734,-0.17578 l -1.009766,-1.00977 z"
+         id="path4220" />
+      <path
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 90.78096,97.606865 1.009766,1.00977 c 0.06437,-0.0642 0.07931,-0.17774 0.177734,-0.17774 l 1.310547,0 c 0.09815,0 0.113893,0.11194 0.177735,0.17578 l 1.007812,-1.00781 c -0.06384,-0.0638 -0.07763,-0.17773 -0.175781,-0.17773 l -3.330078,0 c -0.09842,0 -0.113364,0.11358 -0.177735,0.17773 z"
+         id="rect4159" />
+    </g>
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector1terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-2.018631"
+       y="-2.0185471"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0185471"
+       x="-2.018631"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector1pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <g
+       style="opacity:1"
+       transform="translate(-106.65443,-99.447685)"
+       id="g4843">
+      <rect
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect5450"
+         width="2.019685"
+         height="2.019685"
+         x="105.64434"
+         y="98.437843"
+         rx="0.35433072"
+         ry="0.35433072" />
+      <path
+         id="path5452"
+         d="m 108.49605,101.29045 -1.00976,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.17578,0.17773 l -1.31055,0 c -0.0982,0 -0.11341,-0.1134 -0.17774,-0.17773 l -1.00976,1.00976 c 0.0644,0.0642 0.0793,0.17774 0.17773,0.17774 l 3.33008,0 c 0.0982,0 0.11194,-0.11389 0.17578,-0.17774 z"
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5454"
+         d="m 107.48824,98.614675 c 0.0638,0.0638 0.17578,0.0796 0.17578,0.17774 l 0,1.310535 c 0,0.0984 -0.11358,0.11337 -0.17773,0.17774 l 1.00976,1.00976 c 0.0638,-0.0638 0.17774,-0.0776 0.17774,-0.17578 l 0,-3.332025 c 0,-0.0982 -0.1139,-0.11194 -0.17774,-0.17578 l -1.00781,1.00781 z"
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5456"
+         d="m 104.81246,97.606865 c -0.064,0.0638 -0.17774,0.0779 -0.17774,0.17578 l 0,3.332025 c 0,0.0979 0.11372,0.11198 0.17774,0.17578 l 1.00976,-1.00976 c -0.0643,-0.0643 -0.17773,-0.0796 -0.17773,-0.17774 l 0,-1.310535 c 0,-0.0979 0.11372,-0.11198 0.17773,-0.17578 l -1.00976,-1.00977 z"
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         id="path5458"
+         d="m 104.81246,97.606865 1.00976,1.00977 c 0.0644,-0.0642 0.0793,-0.17774 0.17774,-0.17774 l 1.31054,0 c 0.0981,0 0.1139,0.11194 0.17774,0.17578 l 1.00781,-1.00781 c -0.0638,-0.0638 -0.0776,-0.17773 -0.17578,-0.17773 l -3.33008,0 c -0.0984,0 -0.11336,0.11358 -0.17773,0.17773 z"
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0196838"
+       x="12.01181"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector2terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector2pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="12.01181"
+       y="-2.0196838"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <g
+       style="opacity:1"
+       transform="translate(-106.65418,-99.447685)"
+       id="g4856">
+      <rect
+         ry="0.35433072"
+         rx="0.35433072"
+         y="98.436707"
+         x="119.67478"
+         height="2.019685"
+         width="2.019685"
+         id="rect5464"
+         style="opacity:0.95;fill:#8c8663;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+      <path
+         style="opacity:0.95;fill:#5e5b43;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 122.5265,101.28931 -1.00977,-1.00976 c -0.0638,0.064 -0.0779,0.17773 -0.17578,0.17773 l -1.31055,0 c -0.0982,0 -0.1134,-0.1134 -0.17773,-0.17773 l -1.00977,1.00976 c 0.0644,0.0642 0.0793,0.17774 0.17774,0.17774 l 3.33008,0 c 0.0982,0 0.11194,-0.11389 0.17578,-0.17774 z"
+         id="path5466" />
+      <path
+         style="opacity:0.95;fill:#80795b;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 121.51869,98.613538 c 0.0638,0.0638 0.17578,0.0796 0.17578,0.17774 l 0,1.310532 c 0,0.0984 -0.11359,0.11337 -0.17774,0.17774 l 1.00977,1.00976 c 0.0638,-0.0638 0.17773,-0.0776 0.17773,-0.17578 l 0,-3.332022 c 0,-0.0982 -0.11389,-0.11194 -0.17773,-0.17578 l -1.00781,1.00781 z"
+         id="path5468" />
+      <path
+         style="opacity:0.95;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 118.8429,97.605728 c -0.064,0.0638 -0.17773,0.0779 -0.17773,0.17578 l 0,3.332022 c 0,0.0979 0.11371,0.11198 0.17773,0.17578 l 1.00977,-1.00976 c -0.0643,-0.0643 -0.17774,-0.0796 -0.17774,-0.17774 l 0,-1.310532 c 0,-0.0979 0.11372,-0.11198 0.17774,-0.17578 l -1.00977,-1.00977 z"
+         id="path5470" />
+      <path
+         style="opacity:0.95;fill:#b8af82;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 118.8429,97.605728 1.00977,1.00977 c 0.0644,-0.0642 0.0793,-0.17774 0.17773,-0.17774 l 1.31055,0 c 0.0981,0 0.11389,0.11194 0.17773,0.17578 l 1.00782,-1.00781 c -0.0638,-0.0638 -0.0776,-0.17773 -0.17578,-0.17773 l -3.33008,0 c -0.0984,0 -0.11337,0.11358 -0.17774,0.17773 z"
+         id="path5472" />
+    </g>
+    <path
+       id="path4872"
+       d="M -19.736739,-11.762362 Z"
+       style="opacity:1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/svg/core/icon/JST-VHR-3N_icon.svg
+++ b/svg/core/icon/JST-VHR-3N_icon.svg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg2"
+   viewBox="0 0 41.882811 37.205755"
+   height="10.500291mm"
+   width="11.82026mm">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(20.939896,20.196407)"
+     id="icon">
+    <path
+       id="bottomface"
+       transform="translate(-20.939896,-13.109794)"
+       d="m 0,1.5058594 0,14.6171876 0,7.972656 c 0,1.177795 0.94915775,2.125 2.1269531,2.125 l 37.6289059,0 c 1.177796,0 2.126953,-0.947205 2.126953,-2.125 l 0,-7.972656 0,-7.9726564 0,-6.6445312 -3.226562,0 0,4.5175781 -35.4316406,0 0,-4.5175781 -3.2246094,0 z"
+       style="opacity:1;fill:#cfcfcf;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0185471"
+       x="-16.050133"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector0terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector0pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-16.050133"
+       y="-2.0185471"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector1terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-2.018631"
+       y="-2.0185471"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0185471"
+       x="-2.018631"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector1pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector2pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="12.01181"
+       y="-2.0196838"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="-2.0196838"
+       x="12.01181"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector2terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       ry="2.1259844"
+       rx="2.1259844"
+       y="-7.0854797"
+       x="-20.939896"
+       height="20.19685"
+       width="41.881889"
+       id="insideface"
+       style="opacity:1;fill:#666666;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <path
+       transform="translate(-20.939896,-13.109794)"
+       id="topface"
+       d="M 2.1269531,6.0234375 C 0.94915779,6.0234375 0,6.9725953 0,8.1503906 L 0,24.095703 c 0,0.940884 0.6092574,1.726314 1.453125,2.007813 l 0,1.888672 c 0,1.177794 0.9472046,2.126953 2.125,2.126953 l 34.724609,0 c 1.177796,0 2.126954,-0.949159 2.126954,-2.126953 l 0,-1.888672 c 0.843867,-0.281499 1.453124,-1.066929 1.453124,-2.007813 l 0,-15.9453124 c 0,-1.1777953 -0.949157,-2.1269531 -2.126953,-2.1269531 l -37.6289059,0 z m 0,2.8359375 11.1249999,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.9042969,0 0,-14.527344 z m 13.2519529,0 11.125,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.904297,0 0,-14.527344 z m 13.251953,0 11.125,0 0,14.527344 -2.904297,0 0,1.417969 -5.316406,0 0,-1.417969 -2.904297,0 0,-14.527344 z"
+       style="opacity:1;fill:#e4e4e4;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector5pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="11.233777"
+       y="3.7163022"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="3.7163022"
+       x="11.233777"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector5terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector4pin"
+       width="4.0393701"
+       height="4.0393701"
+       x="-2.0181732"
+       y="3.7163022"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="3.7163022"
+       x="-2.0181732"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector4terminal"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       ry="0.35433072"
+       rx="0.35433072"
+       y="3.7163019"
+       x="-15.270129"
+       height="4.0393701"
+       width="4.0393701"
+       id="connector3pin"
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="opacity:1;fill:#9a916c;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-miterlimit:4;stroke-dasharray:none"
+       id="connector3terminal"
+       width="4.0393701"
+       height="4.0393701"
+       x="-15.270129"
+       y="3.7163019"
+       rx="0.35433072"
+       ry="0.35433072" />
+    <g
+       style="opacity:1"
+       id="retainingclip">
+      <rect
+         style="fill:#e7e7e7;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4806"
+         width="27.850393"
+         height="7.0866141"
+         x="-13.924105"
+         y="-20.196407" />
+      <rect
+         style="fill:#dbdbdb;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4808"
+         width="4.2519689"
+         height="6.0234356"
+         x="-13.924105"
+         y="-13.109793" />
+      <rect
+         y="-13.109793"
+         x="9.6743202"
+         height="6.0234356"
+         width="4.2519689"
+         id="rect4810"
+         style="fill:#dbdbdb;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         y="-8.2910814"
+         x="-13.924105"
+         height="1.2047244"
+         width="4.2519689"
+         id="rect4812"
+         style="fill:#e2e2e2;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#e2e2e2;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4814"
+         width="4.2519689"
+         height="1.2047244"
+         x="9.6743202"
+         y="-8.2910814" />
+    </g>
+    <g
+       style="opacity:1"
+       transform="translate(30.649565,-4.6793227)"
+       id="g4862">
+      <rect
+         ry="2.1259799"
+         rx="2.1259799"
+         y="0.9602918"
+         x="-49.21497"
+         height="13.464567"
+         width="10.629921"
+         id="rect4854"
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="1.8105338"
+         x="-47.957333"
+         height="11.764083"
+         width="8.1146507"
+         id="rect4856"
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4858"
+         width="10.629921"
+         height="8.0190973"
+         x="-49.21497"
+         y="6.4057612"
+         rx="2.1259799"
+         ry="1.2661706" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect4860"
+         width="8.1146507"
+         height="5.8820415"
+         x="-47.957333"
+         y="7.4742889"
+         rx="1.32838" />
+      <rect
+         ry="1.32838"
+         rx="1.32838"
+         y="1.8105336"
+         x="-47.957333"
+         height="4.5952277"
+         width="8.114646"
+         id="rect4892"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         ry="0.70866144"
+         rx="0.70866144"
+         y="3.3223116"
+         x="-47.001991"
+         height="1.571671"
+         width="6.2039642"
+         id="rect4888"
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    </g>
+    <g
+       style="opacity:1"
+       transform="translate(57.153473,-4.6793229)"
+       id="g5363">
+      <rect
+         ry="2.1259799"
+         rx="2.1259799"
+         y="0.9602918"
+         x="-49.21497"
+         height="13.464567"
+         width="10.629921"
+         id="rect5365"
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="1.8105338"
+         x="-47.957333"
+         height="11.764083"
+         width="8.1146507"
+         id="rect5367"
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5369"
+         width="10.629921"
+         height="8.0190973"
+         x="-49.21497"
+         y="6.4057612"
+         rx="2.1259799"
+         ry="1.2661706" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5371"
+         width="8.1146507"
+         height="5.8820415"
+         x="-47.957333"
+         y="7.4742889"
+         rx="1.32838" />
+      <rect
+         ry="1.32838"
+         rx="1.32838"
+         y="1.8105336"
+         x="-47.957333"
+         height="4.5952277"
+         width="8.114646"
+         id="rect5373"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         ry="0.70866144"
+         rx="0.70866144"
+         y="3.3223116"
+         x="-47.001991"
+         height="1.571671"
+         width="6.2039642"
+         id="rect5375"
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+    </g>
+    <g
+       id="g5349"
+       transform="translate(43.901517,-4.6793226)"
+       style="opacity:1">
+      <rect
+         style="fill:#9d855f;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5351"
+         width="10.629921"
+         height="13.464567"
+         x="-49.21497"
+         y="0.9602918"
+         rx="2.1259799"
+         ry="2.1259799" />
+      <rect
+         style="fill:#584932;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5353"
+         width="8.1146507"
+         height="11.764083"
+         x="-47.957333"
+         y="1.8105338"
+         rx="1.32838" />
+      <rect
+         ry="1.2661706"
+         rx="2.1259799"
+         y="6.4057612"
+         x="-49.21497"
+         height="8.0190973"
+         width="10.629921"
+         id="rect5355"
+         style="fill:#ca9a55;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         rx="1.32838"
+         y="7.4742889"
+         x="-47.957333"
+         height="5.8820415"
+         width="8.1146507"
+         id="rect5357"
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118" />
+      <rect
+         style="fill:#514120;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5359"
+         width="8.114646"
+         height="4.5952277"
+         x="-47.957333"
+         y="1.8105336"
+         rx="1.32838"
+         ry="1.32838" />
+      <rect
+         style="fill:#b4a57a;fill-opacity:1;stroke:none;stroke-width:1.77165353;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95294118"
+         id="rect5361"
+         width="6.2039642"
+         height="1.571671"
+         x="-47.001991"
+         y="3.3223116"
+         rx="0.70866144"
+         ry="0.70866144" />
+    </g>
+  </g>
+</svg>

--- a/svg/core/pcb/JST-B3P-VH_pcb.svg
+++ b/svg/core/pcb/JST-B3P-VH_pcb.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg2"
+   viewBox="0 0 334.75214 465.35436"
+   version="1.2"
+   height="0.46535435in"
+   width="0.33475214in">
+  <metadata
+     id="metadata26">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs24" />
+  <desc
+     id="desc4">Fritzing footprint SVG</desc>
+  <g
+     id="copper1">
+    <g
+       id="copper0">
+      <circle
+         style="fill:none;stroke:#f7bd13;stroke-width:20;stroke-opacity:1"
+         r="29"
+         id="connector0pin"
+         cy="76.759926"
+         cx="189.13058" />
+      <circle
+         style="fill:none;stroke:#f7bd13;stroke-width:20;stroke-opacity:1"
+         r="29"
+         id="connector1pin"
+         cy="232.75993"
+         cx="189.13058" />
+      <circle
+         style="fill:none;stroke:#f7bd13;stroke-width:20;stroke-opacity:1"
+         r="29"
+         id="connector2pin"
+         cy="388.75992"
+         cx="189.13058" />
+    </g>
+  </g>
+  <g
+     transform="translate(119.13059,6.7599295)"
+     id="silkscreen">
+    <line
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none"
+       id="line7"
+       y2="448.5"
+       y1="3.5000091"
+       x2="-113.98885"
+       x1="-113.98885" />
+    <line
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none"
+       id="line9"
+       y2="417.84244"
+       y1="417.84244"
+       x2="205.79646"
+       x1="148.8694" />
+    <line
+       style="stroke:#ffffff;stroke-width:9.65012169;stroke-miterlimit:4;stroke-dasharray:none"
+       id="line11"
+       y2="29.157587"
+       y1="422.84244"
+       x2="210.79646"
+       x1="210.79646" />
+    <line
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none"
+       id="line13"
+       y2="-1.7599293"
+       y1="-1.7599293"
+       x2="-119.13059"
+       x1="148.8694" />
+    <line
+       x1="143.72766"
+       x2="143.72766"
+       y1="448.5"
+       y2="3.5000091"
+       id="line4338"
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none" />
+    <line
+       x1="-119.13058"
+       x2="148.8694"
+       y1="453.59439"
+       y2="453.59439"
+       id="line4342"
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none" />
+    <line
+       x1="148.8694"
+       x2="205.79646"
+       y1="34.157585"
+       y2="34.157585"
+       id="line4344"
+       style="stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/svg/core/pcb/JST-VHR-3N_pcb.svg
+++ b/svg/core/pcb/JST-VHR-3N_pcb.svg
@@ -80,4 +80,28 @@
          style="stroke:#f7bd13;stroke-opacity:1" />
     </g>
   </g>
+  <g
+     id="unknown">
+    <circle
+       style="fill:none;stroke:none;stroke-width:20;stroke-opacity:1"
+       r="29"
+       cy="70"
+       cx="70"
+       id="connector3pin"
+       gorn="0.3.0.0" />
+    <circle
+       style="fill:none;stroke:none;stroke-width:20;stroke-opacity:0.94117647"
+       r="29"
+       cy="226"
+       cx="70"
+       id="connector4pin"
+       gorn="0.3.0.1" />
+    <circle
+       style="fill:none;stroke:none;stroke-width:20;stroke-opacity:1"
+       r="29"
+       cy="382"
+       cx="70"
+       id="connector5pin"
+       gorn="0.3.0.2" />
+  </g>
 </svg>

--- a/svg/core/pcb/JST-VHR-3N_pcb.svg
+++ b/svg/core/pcb/JST-VHR-3N_pcb.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="0.14in"
+   version="1.2"
+   height="0.452in"
+   viewBox="0 0 140 452"
+   id="svg2">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <desc
+     id="desc4">
+    <referenceFile>nsjumper_3_0.156in_pcb.svg</referenceFile>
+  </desc>
+  <desc
+     id="desc6">Fritzing footprint SVG</desc>
+  <g
+     gorn="0.2"
+     id="silkscreen">
+    <!-- 120 -->
+  </g>
+  <g
+     gorn="0.3"
+     id="copper1">
+    <g
+       gorn="0.3.0"
+       id="copper0">
+      <rect
+         style="fill:none;fill-opacity:0.94117647;stroke:#f7bd13;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4156"
+         width="58"
+         height="58"
+         x="41"
+         y="41" />
+      <circle
+         stroke="rgb(255, 191, 0)"
+         stroke-width="20"
+         gorn="0.3.0.0"
+         id="connector0pin"
+         fill="none"
+         cx="70"
+         cy="70"
+         r="29"
+         style="stroke:#f7bd13;stroke-opacity:1" />
+      <circle
+         stroke="rgb(255, 191, 0)"
+         stroke-width="20"
+         gorn="0.3.0.1"
+         id="connector1pin"
+         fill="none"
+         cx="70"
+         cy="226"
+         r="29"
+         style="stroke:#f8bd12;stroke-opacity:0.94117647" />
+      <circle
+         stroke="rgb(255, 191, 0)"
+         stroke-width="20"
+         gorn="0.3.0.2"
+         id="connector2pin"
+         fill="none"
+         cx="70"
+         cy="382"
+         r="29"
+         style="stroke:#f7bd13;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/svg/core/schematic/4070_schematic.svg
+++ b/svg/core/schematic/4070_schematic.svg
@@ -1,0 +1,896 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg2"
+   viewBox="0 0 56.259966 57.6"
+   height="0.80000001in"
+   width="0.7813884in"
+   y="0in"
+   x="0in"
+   version="1.2">
+  <metadata
+     id="metadata112">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs110" />
+  <g
+     transform="translate(0.00498486,0)"
+     id="g4"
+     partID="18813740">
+    <g
+       id="schematic"
+       gorn="0.1">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:0.89999998;stroke-linecap:round;stroke-linejoin:round"
+         id="rect7"
+         height="56.700001"
+         y="0.44999999"
+         width="27"
+         x="14.4" />
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line10"
+         x2="14.4"
+         x1="0.34999901"
+         y2="7.1999998"
+         y1="7.1999998" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="1"
+         id="connector0pin"
+         gorn="0.1.3"
+         height="0.69999802"
+         y="6.8499999"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector0terminal"
+         gorn="0.1.4"
+         height="0.699998"
+         y="6.85"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text15"
+         font-size="2.5"
+         class="text"
+         y="6.1500001"
+         x="7.1999998">1</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line17"
+         x2="14.4"
+         x1="0.34999901"
+         y2="14.4"
+         y1="14.4" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="2"
+         id="connector1pin"
+         gorn="0.1.8"
+         height="0.69999802"
+         y="14.05"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector1terminal"
+         gorn="0.1.9"
+         height="0.699998"
+         y="14.05"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text22"
+         font-size="2.5"
+         class="text"
+         y="13.35"
+         x="7.1999998">2</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line24"
+         x2="14.4"
+         x1="0.34999901"
+         y2="21.6"
+         y1="21.6" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="3"
+         id="connector2pin"
+         gorn="0.1.13"
+         height="0.69999802"
+         y="21.25"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector2terminal"
+         gorn="0.1.14"
+         height="0.699998"
+         y="21.25"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text29"
+         font-size="2.5"
+         class="text"
+         y="20.549999"
+         x="7.1999998">3</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line31"
+         x2="14.4"
+         x1="0.34999901"
+         y2="28.799999"
+         y1="28.799999" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="4"
+         id="connector3pin"
+         gorn="0.1.18"
+         height="0.69999802"
+         y="28.450001"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector3terminal"
+         gorn="0.1.19"
+         height="0.699998"
+         y="28.45"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text36"
+         font-size="2.5"
+         class="text"
+         y="27.75"
+         x="7.1999998">4</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line38"
+         x2="14.4"
+         x1="0.34999901"
+         y2="36"
+         y1="36" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="5"
+         id="connector4pin"
+         gorn="0.1.23"
+         height="0.69999802"
+         y="35.650002"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector4terminal"
+         gorn="0.1.24"
+         height="0.699998"
+         y="35.65"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text43"
+         font-size="2.5"
+         class="text"
+         y="34.950001"
+         x="7.1999998">5</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line45"
+         x2="14.4"
+         x1="0.34999901"
+         y2="43.200001"
+         y1="43.200001" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="6"
+         id="connector5pin"
+         gorn="0.1.28"
+         height="0.69999802"
+         y="42.849998"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector5terminal"
+         gorn="0.1.29"
+         height="0.699998"
+         y="42.85"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text50"
+         font-size="2.5"
+         class="text"
+         y="42.150002"
+         x="7.1999998">6</text>
+      <line
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round"
+         id="line52"
+         x2="14.4"
+         x1="0.34999901"
+         y2="50.400002"
+         y1="50.400002" />
+      <rect
+         style="fill:none;stroke-width:0"
+         connectorName="7"
+         id="connector6pin"
+         gorn="0.1.33"
+         height="0.69999802"
+         y="50.049999"
+         width="14.4"
+         x="0" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector6terminal"
+         gorn="0.1.34"
+         height="0.699998"
+         y="50.05"
+         width="0"
+         x="0" />
+      <text
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+         id="text57"
+         font-size="2.5"
+         class="text"
+         y="49.349998"
+         x="7.1999998">7</text>
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector13terminal"
+         gorn="0.1.39"
+         height="0.699998"
+         y="6.85"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector12terminal"
+         gorn="0.1.44"
+         height="0.699998"
+         y="14.05"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector11terminal"
+         gorn="0.1.49"
+         height="0.699998"
+         y="21.25"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector10terminal"
+         gorn="0.1.54"
+         height="0.699998"
+         y="28.45"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector9terminal"
+         gorn="0.1.59"
+         height="0.699998"
+         y="35.65"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector8terminal"
+         gorn="0.1.64"
+         height="0.699998"
+         y="42.85"
+         width="0"
+         x="50.4" />
+      <g
+         style="fill:none;stroke-width:0"
+         id="connector7terminal"
+         gorn="0.1.69"
+         height="0.699998"
+         y="50.05"
+         width="0"
+         x="50.4" />
+      <line
+         id="line80"
+         x2="55.799999"
+         x1="41.400002"
+         y2="28.800001"
+         y1="28.800001"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <line
+         id="line59"
+         x2="55.899998"
+         x1="41.5"
+         y2="7.1999998"
+         y1="7.1999998"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="14"
+         id="connector13pin"
+         gorn="0.1.38"
+         height="0.69999802"
+         y="6.8499999"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text64"
+         font-size="2.5"
+         class="text"
+         y="6.1500001"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">14</text>
+      <line
+         id="line66"
+         x2="55.899998"
+         x1="41.5"
+         y2="14.4"
+         y1="14.4"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="13"
+         id="connector12pin"
+         gorn="0.1.43"
+         height="0.69999802"
+         y="14.05"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text71"
+         font-size="2.5"
+         class="text"
+         y="13.35"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">13</text>
+      <line
+         id="line73"
+         x2="55.899998"
+         x1="41.5"
+         y2="21.6"
+         y1="21.6"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="12"
+         id="connector11pin"
+         gorn="0.1.48"
+         height="0.69999802"
+         y="21.25"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text78"
+         font-size="2.5"
+         class="text"
+         y="20.549999"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">12</text>
+      <rect
+         connectorname="11"
+         id="connector10pin"
+         gorn="0.1.53"
+         height="0.69999802"
+         y="28.450003"
+         width="14.4"
+         x="41.045017"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text85"
+         font-size="2.5"
+         class="text"
+         y="27.750002"
+         x="48.245018"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">11</text>
+      <line
+         id="line87"
+         x2="55.899998"
+         x1="41.5"
+         y2="36"
+         y1="36"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="10"
+         id="connector9pin"
+         gorn="0.1.58"
+         height="0.69999802"
+         y="35.650002"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text92"
+         font-size="2.5"
+         class="text"
+         y="34.950001"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">10</text>
+      <line
+         id="line94"
+         x2="55.899998"
+         x1="41.5"
+         y2="43.200001"
+         y1="43.200001"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="9"
+         id="connector8pin"
+         gorn="0.1.63"
+         height="0.69999802"
+         y="42.849998"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text99"
+         font-size="2.5"
+         class="text"
+         y="42.150002"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">9</text>
+      <line
+         id="line101"
+         x2="55.899998"
+         x1="41.5"
+         y2="50.400002"
+         y1="50.400002"
+         style="fill:none;stroke:#787878;stroke-width:0.69999802;stroke-linecap:round;stroke-linejoin:round" />
+      <rect
+         connectorname="8"
+         id="connector7pin"
+         gorn="0.1.68"
+         height="0.69999802"
+         y="50.049999"
+         width="14.4"
+         x="41.849998"
+         style="fill:none;stroke-width:0" />
+      <text
+         id="text106"
+         font-size="2.5"
+         class="text"
+         y="49.349998"
+         x="49.049999"
+         style="font-size:2.5px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0">8</text>
+    </g>
+  </g>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.40933657px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+     x="20.531496"
+     y="49.52338"
+     id="text3736"><tspan
+       id="tspan3738"
+       x="20.531496"
+       y="49.52338">GND</tspan></text>
+  <text
+     id="text4643"
+     y="55.912319"
+     x="28.567329"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.79270411px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       y="55.912319"
+       x="28.567329"
+       id="tspan4645">4070</tspan></text>
+  <g
+     id="g2484"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.300027,40.182646)"
+     style="text-align:start;text-anchor:start">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.954582"
+       y="-135.61552"
+       id="text2486"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2488"
+         x="41.954582"
+         y="-135.61552">B</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.371841"
+       y="-131.01935"
+       id="text2490"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2492"
+         x="41.371841"
+         y="-131.01935"
+         style="font-size:8px;text-align:start;text-anchor:start">4</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.300027,47.279838)"
+     id="g2494">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2496"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2498">A</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2500"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan2502">4</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.300027,54.590429)"
+     id="g2504">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2506"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2508">Q</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2510"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan2512">4</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.343162,61.800485)"
+     id="g2514">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2516"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2518">Q</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2520"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan2522">3</tspan></text>
+  </g>
+  <g
+     id="g2524"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.343162,69.013232)"
+     style="text-align:start;text-anchor:start">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.954582"
+       y="-135.61552"
+       id="text2526"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2528"
+         x="41.954582"
+         y="-135.61552">B</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.371841"
+       y="-131.01935"
+       id="text2530"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2532"
+         x="41.371841"
+         y="-131.01935"
+         style="font-size:8px;text-align:start;text-anchor:start">3</tspan></text>
+  </g>
+  <g
+     id="g2544"
+     transform="matrix(0,-0.20077803,0.20077804,0,8.3304074,32.896757)"
+     style="text-align:start;text-anchor:start">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.954582"
+       y="-135.61552"
+       id="text2546"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2548"
+         x="41.954582"
+         y="-135.61552">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.371841"
+       y="-131.01935"
+       id="text2550"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2552"
+         x="41.371841"
+         y="-131.01935"
+         style="font-size:8px;text-align:start;text-anchor:start">1</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077804,0.20077804,0,8.1304137,39.993954)"
+     id="g2554">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2556"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2558">B</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2560"
+       y="-131.01935"
+       x="42.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="42.371841"
+         id="tspan2562">1</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077803,0.20077803,0,8.4751091,47.304545)"
+     id="g2564">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2566"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2568">Q</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2570"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan2572">1</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077803,0.20077804,0,8.4751088,54.509222)"
+     id="g2574">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2576"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan2578">Q</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text2580"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan2582">2</tspan></text>
+  </g>
+  <g
+     id="g2584"
+     transform="matrix(0,-0.20077804,0.20077804,0,8.3304074,61.721967)"
+     style="text-align:start;text-anchor:start">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="41.954582"
+       y="-135.61552"
+       id="text2586"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2588"
+         x="41.954582"
+         y="-135.61552">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       x="42.371841"
+       y="-131.01935"
+       id="text2590"
+       transform="matrix(0,1,-1,0,0,0)"><tspan
+         id="tspan2592"
+         x="42.371841"
+         y="-131.01935"
+         style="font-size:8px;text-align:start;text-anchor:start">2</tspan></text>
+  </g>
+  <g
+     id="g3262"
+     transform="matrix(0,0.14501303,0.14501303,0,20.930571,9.4559616)">
+    <path
+       id="path3264"
+       d="M 68.876949,25 84.218752,25 84.09375,-45"
+       style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3266"
+       d="m 30.5,15 -26.40625,0 0,-20 30,-30 0,-10"
+       style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3268"
+       d="m 30.5,35 -46.40625,0 0,-80"
+       style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-0.40625,0.020574)"
+       id="g6438">
+      <g
+         id="g2560"
+         transform="translate(26.5,-39.5)">
+        <path
+           id="path3516"
+           style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m -2.75,81.500005 c -1.597374,2.6444 -2.25,3 -2.25,3 l -4.65625,0 2,-2.4375 C -7.65625,82.062505 -2,75.062451 -2,64.5 -2,53.937549 -7.65625,46.9375 -7.65625,46.9375 l -2,-2.4375 4.65625,0 c 0.78125,0.9375 1.421875,1.65625 2.21875,3 C -0.908531,50.599815 2,56.526646 2,64.5 2,72.45065 -0.896697,78.379425 -2.75,81.500005 Z" />
+      </g>
+      <g
+         transform="translate(26,-39.535919)"
+         id="g7018">
+        <path
+           d="m 44.5,64.515345 c 0,0 -7.778563,17.99492 -27.224972,17.99492 l -15.4640291,0.0051 C 9.61868,71.517852 9.626914,57.522021 1.8215884,46.515344 l 15.4534396,0.0051 c 19.446409,0 27.224972,17.99492 27.224972,17.99492 z"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="path6728" />
+      </g>
+    </g>
+  </g>
+  <use
+     x="0"
+     y="0"
+     xlink:href="#g3262"
+     id="use5537"
+     transform="matrix(-1,0,0,-1,55.90997,57.6)"
+     width="220"
+     height="220" />
+  <use
+     height="220"
+     width="220"
+     transform="matrix(-1,0,0,1,55.90997,7.2000008)"
+     id="use5539"
+     xlink:href="#g3262"
+     y="0"
+     x="0" />
+  <use
+     height="220"
+     width="220"
+     transform="matrix(1,0,0,-1,-3.2881602e-8,50.4)"
+     id="use5541"
+     xlink:href="#g3262"
+     y="0"
+     x="0" />
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077804,0.20077803,0,8.130414,68.962848)"
+     id="g5362">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text5364"
+       y="-135.61552"
+       x="41.954582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.954582"
+         id="tspan5366">B</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text5368"
+       y="-131.01935"
+       x="42.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="42.371841"
+         id="tspan5370">2</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20077224,0.20077224,0,31.343162,76.109295)"
+     id="g5372">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text5374"
+       y="-135.61552"
+       x="41.454582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:end;writing-mode:lr-tb;text-anchor:end;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="41.454582"
+         id="tspan5376">A</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text5378"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan5380">3</tspan></text>
+  </g>
+  <g
+     style="text-align:start;text-anchor:start"
+     transform="matrix(0,-0.20076887,0.20076887,0,29.861078,32.798326)"
+     id="g3543">
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text3413"
+       y="-135.61552"
+       x="35.204582"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         y="-135.61552"
+         x="35.204582"
+         id="tspan3415">V</tspan></text>
+    <text
+       transform="matrix(0,1,-1,0,0,0)"
+       id="text3417"
+       y="-131.01935"
+       x="41.371841"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;line-height:100%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:8px;text-align:start;text-anchor:start"
+         y="-131.01935"
+         x="41.371841"
+         id="tspan3419">DD</tspan></text>
+  </g>
+</svg>

--- a/svg/core/schematic/JST-B3P-VH_schematic.svg
+++ b/svg/core/schematic/JST-B3P-VH_schematic.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 14.4 21.6"
+   height="0.3in"
+   width="0.2in"
+   y="0in"
+   x="0in"
+   id="svg2"
+   version="1.2">
+  <metadata
+     id="metadata31">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs29" />
+  <g
+     id="schematic">
+    <line
+       y2="3.6"
+       x2="7.471"
+       y1="3.6"
+       x1="0.35"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="connector0pin" />
+    <rect
+       height="0.208"
+       width="0.546"
+       fill="none"
+       y="3.504"
+       x="-0.273"
+       id="connector0terminal" />
+    <polyline
+       id="polyline6"
+       points="9.898,1.643 14.1,3.6 9.898,5.556"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none" />
+    <line
+       y2="3.6"
+       x2="4.781"
+       y1="3.6"
+       x1="14.1"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="line" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text9"
+       y="2.5799999"
+       x="5.0500002"
+       font-size="2.5pt"
+       class="text">1</text>
+    <line
+       y2="10.8"
+       x2="7.471"
+       y1="10.8"
+       x1="0.35"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="connector1pin" />
+    <rect
+       height="0.208"
+       width="0.546"
+       fill="none"
+       y="10.704"
+       x="-0.273"
+       id="connector1terminal" />
+    <polyline
+       id="polyline13"
+       points="9.898,8.843 14.1,10.8 9.898,12.756"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none" />
+    <line
+       y2="10.8"
+       x2="4.781"
+       y1="10.8"
+       x1="14.1"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="line15" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text17"
+       y="9.7799997"
+       x="5.0500002"
+       font-size="2.5pt"
+       class="text">2</text>
+    <line
+       y2="18"
+       x2="7.471"
+       y1="18"
+       x1="0.35"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="connector2pin" />
+    <rect
+       height="0.208"
+       width="0.546"
+       fill="none"
+       y="17.904"
+       x="-0.273"
+       id="connector2terminal" />
+    <polyline
+       id="polyline21"
+       points="9.898,16.043 14.1,18 9.898,19.956"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none" />
+    <line
+       y2="18"
+       x2="4.781"
+       y1="18"
+       x1="14.1"
+       stroke-linejoin="round"
+       stroke-linecap="round"
+       stroke-width="0.7"
+       stroke="#000000"
+       fill="none"
+       id="line23" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text25"
+       y="16.98"
+       x="5.0500002"
+       font-size="2.5pt"
+       class="text">3</text>
+  </g>
+</svg>

--- a/svg/core/schematic/JST-VHR-3N_schematic.svg
+++ b/svg/core/schematic/JST-VHR-3N_schematic.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 14.4 21.6"
+   height="0.3in"
+   width="0.2in"
+   y="0in"
+   x="0in"
+   id="svg2"
+   version="1.2">
+  <metadata
+     id="metadata31">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs29" />
+  <g
+     id="schematic">
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="3.5999999"
+       x2="6.8565164"
+       y1="3.5999999"
+       x1="13.852516"
+       id="connector3pin" />
+    <rect
+       transform="scale(-1,1)"
+       style="fill:none"
+       height="0.208"
+       width="0.546"
+       y="3.5039999"
+       x="-14.454516"
+       id="connector3terminal" />
+    <polyline
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       transform="matrix(-1,0,0,1,14.202516,0)"
+       id="polyline6"
+       points="14.1,5.557 9.928,3.6 14.1,1.643" />
+    <rect
+       transform="scale(-1,1)"
+       id="connector0terminal"
+       x="-4.2835321"
+       y="3.5039999"
+       width="0.546"
+       height="0.208"
+       style="fill:none" />
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="3.5999999"
+       x2="9.3985167"
+       y1="3.5999999"
+       x1="4.0925169"
+       id="connector0pin" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text9"
+       y="2.5799999"
+       x="9.1989031"
+       font-size="2.5pt"
+       class="text">1</text>
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="10.8"
+       x2="6.8565164"
+       y1="10.8"
+       x1="13.852516"
+       id="connector4pin" />
+    <rect
+       transform="scale(-1,1)"
+       style="fill:none"
+       height="0.208"
+       width="0.546"
+       y="10.704"
+       x="-14.454516"
+       id="connector4terminal" />
+    <polyline
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       transform="matrix(-1,0,0,1,14.202516,0)"
+       id="polyline13"
+       points="14.1,12.757 9.928,10.8 14.1,8.843" />
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="10.8"
+       x2="9.3985167"
+       y1="10.8"
+       x1="4.0925169"
+       id="connector1pin" />
+    <rect
+       transform="scale(-1,1)"
+       id="connector1terminal"
+       x="-4.2835321"
+       y="10.704"
+       width="0.546"
+       height="0.208"
+       style="fill:none" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text17"
+       y="9.7799997"
+       x="9.1989031"
+       font-size="2.5pt"
+       class="text">2</text>
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="18"
+       x2="6.8565164"
+       y1="18"
+       x1="13.852516"
+       id="connector5pin" />
+    <rect
+       transform="scale(-1,1)"
+       style="fill:none"
+       height="0.208"
+       width="0.546"
+       y="17.903999"
+       x="-14.454516"
+       id="connector5terminal" />
+    <polyline
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       transform="matrix(-1,0,0,1,14.202516,0)"
+       id="polyline21"
+       points="14.1,19.957 9.928,18 14.1,16.043" />
+    <line
+       style="fill:none;stroke:#000000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:round"
+       y2="18"
+       x2="9.3985167"
+       y1="18"
+       x1="4.0925169"
+       id="connector2pin" />
+    <rect
+       transform="scale(-1,1)"
+       id="connector2terminal"
+       x="-4.2835321"
+       y="17.903999"
+       width="0.546"
+       height="0.208"
+       style="fill:none" />
+    <text
+       style="font-size:3.125px;font-family:'Droid Sans';text-anchor:middle;fill:#8c8c8c;stroke:none;stroke-width:0"
+       id="text25"
+       y="16.98"
+       x="9.1989031"
+       font-size="2.5pt"
+       class="text">3</text>
+  </g>
+</svg>


### PR DESCRIPTION
These connectors are commonly used as connectors for Dagu robot main
motors. They do not play nicely with 0.1 in strip or breadboard. The male
can be mounted on stripboard if the centre hole is used for location purposes,
holes drilled between the tracks and solder traces added to make high
current double tracks for the outer connectors.

The Fritzing part in this case has pin0 as the centre pin so that the male
header locates symmetrically on stripboard. The labelling is still pin 1
is the leftmost however.

![jst-vh-breadboard](https://cloud.githubusercontent.com/assets/4488509/16142913/56109a9a-3461-11e6-9798-bb197f2b2a66.png)
![jst-vh-pcb](https://cloud.githubusercontent.com/assets/4488509/16142912/560c21b8-3461-11e6-9557-f1629c5392e9.png)
![jst-vh-schermatic](https://cloud.githubusercontent.com/assets/4488509/16142914/5612ca4a-3461-11e6-9795-d523c827bc04.png)
