### PR TITLE
Change diode silkscreen stroke-linecap from invalid flat to butt

### DIFF
--- a/svg/core/pcb/DO-41_diode_2_300mil_pcb.svg
+++ b/svg/core/pcb/DO-41_diode_2_300mil_pcb.svg
@@ -2,13 +2,13 @@
 <svg baseProfile="tiny" height="0.100in" version="1.2" viewBox="0 0 382 100" width="0.382in" xmlns="http://www.w3.org/2000/svg">
  <desc>Fritzing footprint SVG</desc>
  <g id="silkscreen">
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="83" x2="96" y1="50" y2="50"/>
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="291" x2="298" y1="50" y2="50"/>
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="96" x2="291" y1="5" y2="5"/>
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="291" x2="291" y1="5" y2="95"/>
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="291" x2="96" y1="95" y2="95"/>
-  <line stroke="white" stroke-width="10" stroke-linecap="flat" x1="96" x2="96" y1="95" y2="5"/>
-  <line stroke="white" stroke-width="20" stroke-linecap="flat" x1="116" x2="116" y1="95" y2="5"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="83" x2="96" y1="50" y2="50"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="291" x2="298" y1="50" y2="50"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="96" x2="291" y1="5" y2="5"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="291" x2="291" y1="5" y2="95"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="291" x2="96" y1="95" y2="95"/>
+  <line stroke="white" stroke-width="10" stroke-linecap="butt" x1="96" x2="96" y1="95" y2="5"/>
+  <line stroke="white" stroke-width="20" stroke-linecap="butt" x1="116" x2="116" y1="95" y2="5"/>
  </g>
  <g id="copper1"><g id="copper0">
   <rect fill="none" height="62" stroke="rgb(255, 191, 0)" stroke-width="20" width="62" x="10" y="19"/>

--- a/svg/core/pcb/P1000K_diode_10A.svg
+++ b/svg/core/pcb/P1000K_diode_10A.svg
@@ -26,13 +26,13 @@
  </g>
   </g>
  <g   id="silkscreen">
-  <line   stroke="#ffffff" id="line3298" stroke-linecap="flat" y1="10.651714" y2="10.651714" x1="6.1424065" stroke-width="1.37469959" x2="7.3340955"/>
-  <line   stroke="#ffffff" id="line3300" stroke-linecap="flat" y1="10.651714" y2="10.651714" x1="25.209429" stroke-width="1.37469959" x2="25.851107"/>
-  <line   stroke="#ffffff" id="line3302" stroke-linecap="flat" y1="1.3746928" y2="1.3746928" x1="7.3340955" stroke-width="1.37469959" x2="25.209429"/>
-  <line   stroke="#ffffff" id="line3304" stroke-linecap="flat" y1="1.3746928" y2="19.928736" x1="25.209429" stroke-width="1.37469959" x2="25.209429"/>
-  <line   stroke="#ffffff" id="line3306" stroke-linecap="flat" y1="19.928736" y2="19.928736" x1="25.209429" stroke-width="1.37469959" x2="7.3340955"/>
-  <line   stroke="#ffffff" id="line3308" stroke-linecap="flat" y1="19.928736" y2="1.3746928" x1="7.3340955" stroke-width="1.37469959" x2="7.3340955"/>
-  <line   stroke="#ffffff" id="line3310" stroke-linecap="flat" y1="19.928736" y2="1.3746928" x1="9.1674633" stroke-width="2.74939919" x2="9.1674633"/>
-  <line   stroke="#ffffff" id="line3298-4" stroke-linecap="flat" y1="10.651714" y2="10.651714" x1="25.10037" stroke-width="1.37469959" x2="26.292059"/>
+  <line   stroke="#ffffff" id="line3298" stroke-linecap="butt" y1="10.651714" y2="10.651714" x1="6.1424065" stroke-width="1.37469959" x2="7.3340955"/>
+  <line   stroke="#ffffff" id="line3300" stroke-linecap="butt" y1="10.651714" y2="10.651714" x1="25.209429" stroke-width="1.37469959" x2="25.851107"/>
+  <line   stroke="#ffffff" id="line3302" stroke-linecap="butt" y1="1.3746928" y2="1.3746928" x1="7.3340955" stroke-width="1.37469959" x2="25.209429"/>
+  <line   stroke="#ffffff" id="line3304" stroke-linecap="butt" y1="1.3746928" y2="19.928736" x1="25.209429" stroke-width="1.37469959" x2="25.209429"/>
+  <line   stroke="#ffffff" id="line3306" stroke-linecap="butt" y1="19.928736" y2="19.928736" x1="25.209429" stroke-width="1.37469959" x2="7.3340955"/>
+  <line   stroke="#ffffff" id="line3308" stroke-linecap="butt" y1="19.928736" y2="1.3746928" x1="7.3340955" stroke-width="1.37469959" x2="7.3340955"/>
+  <line   stroke="#ffffff" id="line3310" stroke-linecap="butt" y1="19.928736" y2="1.3746928" x1="9.1674633" stroke-width="2.74939919" x2="9.1674633"/>
+  <line   stroke="#ffffff" id="line3298-4" stroke-linecap="butt" y1="10.651714" y2="10.651714" x1="25.10037" stroke-width="1.37469959" x2="26.292059"/>
  </g>
 </svg>


### PR DESCRIPTION
Fix a typo in a couple of pcb view svg files.  "flat" is not a valid stroke-linecap value.