### PR TITLE
change Intel Edison to be a Part

### DIFF
--- a/core/intel_edison-hirosedf40.fzp
+++ b/core/intel_edison-hirosedf40.fzp
@@ -21,7 +21,7 @@
 <views>
 <breadboardView>
 <layers image='breadboard/intel_edison-hirosedf40_breadboard.svg'>
-<layer layerId='breadboardbreadboard'/>
+<layer layerId='breadboard'/>
 </layers>
 </breadboardView>
 <schematicView>


### PR DESCRIPTION
First of all, you thank you very much for all your efforts. Last week, I used a circuit diagram built with your tools in an Android Hacking Event. 93 students participated and learned about software security. Thanks to your efforts, I was able to built one challenge around the Intel Edison. Anyway, back on topic:

Previously the Intel Edison Computing Module without any breakout board was classified as Breadboard and not as Part. This moved the Intel Edison into the layer of Breadboards. This made it impossible to put the Intel Edison on top of Parts like the [SparkFun GPIO Block](/sparkfun/Fritzing_Parts/commit/9dca354bc97bc871e642fe05f99ecdcb9647cb63) ([DEV-13038](http://learn.sparkfun.com/tutorials/sparkfun-blocks-for-intel-edison---gpio-block)).