### PR TITLE
Added missing whitespace between attributes

### DIFF
--- a/core/Bean_revE.fzp
+++ b/core/Bean_revE.fzp
@@ -158,7 +158,7 @@ Zero wires. Infinite uses. What will you build next?</description>
 <breadboardView>
 <p layer='breadboard' svgId='connector81pin'/></breadboardView>
 <schematicView>
-<p layer='schematic' hybrid='yes' svgId='connector81pin' terminalId='connector81terminal'hybrid='yes' /></schematicView>
+<p layer='schematic' hybrid='yes' svgId='connector81pin' terminalId='connector81terminal' hybrid='yes' /></schematicView>
 <pcbView>
 <p layer='copper0' hybrid='yes' svgId='connector81pad' hybrid='yes' /><p layer='copper1' hybrid='yes' svgId='connector81pad' hybrid='yes' /></pcbView>
 </views>

--- a/core/SparkFun_BadgerStick.fzp
+++ b/core/SparkFun_BadgerStick.fzp
@@ -62,7 +62,7 @@ Please view the tutorial on hacking your badge for more information.</descriptio
 <breadboardView>
 <p layer='breadboard' svgId='connector29pin'/></breadboardView>
 <schematicView>
-<p layer='schematic' svgId='connector29pin' hybrid='yes'terminalId='connector29terminal'/></schematicView>
+<p layer='schematic' svgId='connector29pin' hybrid='yes' terminalId='connector29terminal'/></schematicView>
 <pcbView>
 <p layer='copper0' svgId='connector29pad' hybrid='yes'/><p layer='copper1' svgId='connector29pad' hybrid='yes'/></pcbView>
 </views>


### PR DESCRIPTION
some linter will throw an error if there is no whitespace