### PR TITLE
cleanup family and other tags for microsdmodule.fzp

### DIFF
--- a/core/microsdmodule.fzp
+++ b/core/microsdmodule.fzp
@@ -9,14 +9,14 @@ p, li { white-space: pre-wrap; }
 &lt;/style>&lt;/head>&lt;body style=" font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;">
 &lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">A common microSD card module.&lt;/p>&lt;/body>&lt;/html></description>
  <title>MicroSD Card Module</title>
+ <label>microSD</label>
  <url></url>
  <tags>
   <tag>microsd</tag>
   <tag>module</tag>
  </tags>
  <properties>
-  <property name="variant">variant 1</property>
-  <property name="family">//obosolete//microsd</property>
+  <property name="family">microsd</property>
   <property name="chip">PG6SD</property>
  </properties>
  <views>


### PR DESCRIPTION
Part file core/microsdmodule.fzp had a family of "//obosolete//microsd".

It *appears* from the diff, that in the process of converting from a user format set of files, that the obsolete marker on the family name got left in by accident.

Since there is currently only a single part with the "microsd" family, the variant property is redundant.  There ARE other sd card related parts.  Family values:
```text
sparkfun microsd socket
storage
memory shield
audio playback
data logger
storage connector
```
A little consistency between these would be nice, but not going to play with that for now.