### PR TITLE
cleanup obsolete family text prefixes

### DIFF
--- a/obsolete/AD5206 Digital Potentiometer.fzp
+++ b/obsolete/AD5206 Digital Potentiometer.fzp
@@ -9,7 +9,7 @@
         <tag>SPI</tag>
     </tags>
     <properties>
-        <property name="family">IC-Poti</property>
+        <property name="family">//obsolete//IC-Poti</property>
     <property name="package">DIP28 [THT]</property>
    <property name="Maximum Resistance" showInLabel="yes">10k&#937;</property>
     </properties>

--- a/obsolete/Arduino Ethernet Shield.fzp
+++ b/obsolete/Arduino Ethernet Shield.fzp
@@ -10,7 +10,7 @@
         <tag>Shield</tag>
     </tags>
     <properties>
-        <property name='family'>/obsolete/Arduino Shield</property>        
+        <property name='family'>//obsolete//Arduino Shield</property>
 	<property name='type'>Ethernet</property>
     </properties>
     <description>Ethernet shield for the awesome Arduino microcontroller.</description>

--- a/obsolete/Arduino Fio.fzp
+++ b/obsolete/Arduino Fio.fzp
@@ -13,7 +13,7 @@
         <tag>atmega</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino Fio</property>
     </properties>

--- a/obsolete/Arduino LilyPad.fzp
+++ b/obsolete/Arduino LilyPad.fzp
@@ -9,7 +9,7 @@
         <tag>LilyPad</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino LiliyPad</property>
     </properties>

--- a/obsolete/Arduino Mini Pro.fzp
+++ b/obsolete/Arduino Mini Pro.fzp
@@ -10,7 +10,7 @@
         <tag>Sparkfun</tag>
     </tags>
     <properties>
-        <property name='family'>/obsolete/Microcontroller Board (Arduino)</property>
+        <property name='family'>//obsolete//Microcontroller Board (Arduino)</property>
         <property name='processor'>ATmega</property>
         <property name='variant'>Arduino Pro Mini</property>
     </properties>

--- a/obsolete/Arduino Mini.fzp
+++ b/obsolete/Arduino Mini.fzp
@@ -12,7 +12,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino Mini</property>
    </properties>

--- a/obsolete/Arduino Nano3.fzp
+++ b/obsolete/Arduino Nano3.fzp
@@ -14,7 +14,7 @@
 <tag>microcontrollerboard</tag>
 </tags>
 <properties>
-<property name='family'>/obsolete/microcontroller board (arduino)</property>
+<property name='family'>//obsolete//microcontroller board (arduino)</property>
 <property name='type'>Arduino Nano (3.0)</property>
 </properties>
 <views>

--- a/obsolete/Arduino Nano_v30.fzp
+++ b/obsolete/Arduino Nano_v30.fzp
@@ -11,7 +11,7 @@
         <tag>microcontroller</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino Nano v3.0</property>
     </properties>

--- a/obsolete/Arduino-Fio-v22.fzp
+++ b/obsolete/Arduino-Fio-v22.fzp
@@ -16,7 +16,7 @@ Arduino Fio is compatible with Funnel. It has connections for a Lithium Polymer 
 <tag>microcontrollerboard</tag>
 </tags>
 <properties>
-<property name='family'>/obsolete/microcontroller board (arduino)</property>
+<property name='family'>//obsolete//microcontroller board (arduino)</property>
 <property name='type'>Arduino Fio (v22)</property>
 </properties>
 <views>

--- a/obsolete/Arduino-Pro-Mini-v11.fzp
+++ b/obsolete/Arduino-Pro-Mini-v11.fzp
@@ -158,7 +158,7 @@
 <tag>Pro</tag>
 </tags>
 <properties>
-<property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+<property name="family">//obsolete//Microcontroller Board (Arduino)</property>
 <property name='Voltage'>3.3V</property>
 <property name='Digital Pins'>14</property>
 <property name='Analog Pins'>4</property>

--- a/obsolete/Arduino-Pro-Mini-v13.fzp
+++ b/obsolete/Arduino-Pro-Mini-v13.fzp
@@ -16,7 +16,7 @@ The latest and greatest version of this board breaks out the ADC6 and ADC7 pins 
 <tag>ATmega168</tag>
 </tags>
 <properties>
-<property name='family'>/obsolete/microcontroller board (arduino)</property>
+<property name='family'>//obsolete//microcontroller board (arduino)</property>
 <property name='type'>Arduino Pro Mini (Rev13)</property>
 </properties>
 <views>

--- a/obsolete/Arduino_ADK_MEGA_2560-Rev3.fzp
+++ b/obsolete/Arduino_ADK_MEGA_2560-Rev3.fzp
@@ -23,7 +23,7 @@ For information on using the board with the Android OS, see Google's ADK documen
   <tag> ATmega 2560</tag>
  </tags>
  <properties>
-  <property name="family">/obsolete/microcontroller board (arduino)</property>
+  <property name="family">//obsolete//microcontroller board (arduino)</property>
   <property name="part number"></property>
   <property name="type">Arduino MEGA ADK (Rev3)</property>
  </properties>

--- a/obsolete/Arduino_Leonardo_Rev3.fzp
+++ b/obsolete/Arduino_Leonardo_Rev3.fzp
@@ -15,7 +15,7 @@ The Leonardo differs from all preceding boards in that the ATmega32u4 has built-
 <tag>ATmega32u4</tag>
 </tags>
 <properties>
-<property name='family'>//oboslete//microcontroller board (arduino)</property>
+<property name='family'>//obsolete//microcontroller board (arduino)</property>
 <property name="type">Arduino Leonardo (Rev3)</property>
 </properties>
 <views>

--- a/obsolete/Arduino_Micro_Rev03.fzp
+++ b/obsolete/Arduino_Micro_Rev03.fzp
@@ -17,7 +17,7 @@ The Micro is similar to the Arduino Leonardo in that the ATmega32u4 has built-in
 <tag>REV3</tag>
 </tags>
 <properties>
-<property name='family'>/oboslete/microcontroller board (arduino)</property>
+<property name='family'>//obsolete//microcontroller board (arduino)</property>
 <property name='type'>Arduino Micro (Rev3)</property>
 </properties>
 <views>

--- a/obsolete/Arduino_UNO_R3.fzp
+++ b/obsolete/Arduino_UNO_R3.fzp
@@ -12,7 +12,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino UNO R3</property>
     </properties>

--- a/obsolete/Atmega_168_TQFP32.fzp
+++ b/obsolete/Atmega_168_TQFP32.fzp
@@ -10,7 +10,7 @@
     </tags>
     <properties>
         <property name="package">TQFP32-5MM</property>
-        <property name="family">/obsolete/Microcontroller</property>
+        <property name="family">//obsolete//Microcontroller</property>
         <property name="editable pin labels">true</property>
         <property name="chip label">ATmega168</property>
         <property name="part number"></property>

--- a/obsolete/Battery block 9V.fzp
+++ b/obsolete/Battery block 9V.fzp
@@ -10,7 +10,7 @@
         <tag>user part</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Battery</property>
+        <property name="family">//obsolete//Battery</property>
         <property name="voltage" showInLabel="yes">9V</property>
     </properties>
     <description>Your standard 9 Volts battery block</description>

--- a/obsolete/ELECTRON_90f1556e6dcbdc62b58429de7696758a_7.fzp
+++ b/obsolete/ELECTRON_90f1556e6dcbdc62b58429de7696758a_7.fzp
@@ -20,7 +20,7 @@ p, li { white-space: pre-wrap; }
  </tags>
  <properties>
   <property name="variant">variant 5</property>
-  <property name="family">//obosolete//microcontroller board (arduino compatible)</property>
+  <property name="family">//obsolete//microcontroller board (arduino compatible)</property>
   <property name="name">Electron</property>
   <property name="layer"></property>
   <property name="manufacturer">Particle</property>

--- a/obsolete/EspruinoPico_8fb644a5b6642112445ed6d90bc494d8_6.fzp
+++ b/obsolete/EspruinoPico_8fb644a5b6642112445ed6d90bc494d8_6.fzp
@@ -12,7 +12,7 @@ p, li { white-space: pre-wrap; }
  <url>http://www.espruino.com/Pico</url>
  <tags/>
  <properties>
-  <property name="family">//obosolete//Espruino</property>
+  <property name="family">//obsolete//Espruino</property>
   <property name="variant">variant 1</property>
   <property name="part number"></property>
   <property name="layer"></property>

--- a/obsolete/Generic female header - metal rounded.fzp
+++ b/obsolete/Generic female header - metal rounded.fzp
@@ -6,7 +6,7 @@
     <date>2009-03-05</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">1</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/Generic female header.fzp
+++ b/obsolete/Generic female header.fzp
@@ -6,7 +6,7 @@
     <date>2009-03-05</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">1</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/Generic male header.fzp
+++ b/obsolete/Generic male header.fzp
@@ -6,7 +6,7 @@
     <date>2009-03-05</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">1</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/LED-blue-5mm (2).fzp
+++ b/obsolete/LED-blue-5mm (2).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">blue</property>
  </properties>
  <description>A generic blue LED (~1.8V)</description>

--- a/obsolete/LED-blue-5mm (3).fzp
+++ b/obsolete/LED-blue-5mm (3).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">blue</property>
   <property name="current" showInLabel="yes"></property>
  </properties>

--- a/obsolete/LED-blue-5mm.fzp
+++ b/obsolete/LED-blue-5mm.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">blue</property>
  </properties>

--- a/obsolete/LED-blue-5mm_t1.75.fzp
+++ b/obsolete/LED-blue-5mm_t1.75.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">blue</property>
  </properties>

--- a/obsolete/LED-green-5mm (2).fzp
+++ b/obsolete/LED-green-5mm (2).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">green</property>
  </properties>
  <description>A generic green LED (~1.8V)</description>

--- a/obsolete/LED-green-5mm (3).fzp
+++ b/obsolete/LED-green-5mm (3).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">green</property>
   <property name="current" showInLabel="yes"></property>
  </properties>

--- a/obsolete/LED-green-5mm.fzp
+++ b/obsolete/LED-green-5mm.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">green</property>
  </properties>

--- a/obsolete/LED-green-5mm_t1.75.fzp
+++ b/obsolete/LED-green-5mm_t1.75.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">green</property>
  </properties>

--- a/obsolete/LED-red-5mm (2).fzp
+++ b/obsolete/LED-red-5mm (2).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">red</property>
  </properties>
  <description>A generic red LED (~1.8V)</description>

--- a/obsolete/LED-red-5mm (3).fzp
+++ b/obsolete/LED-red-5mm (3).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">red</property>
   <property name="current" showInLabel="yes"></property>
   <property name="leg" >no</property>

--- a/obsolete/LED-red-5mm.fzp
+++ b/obsolete/LED-red-5mm.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">red</property>
  </properties>

--- a/obsolete/LED-red-5mm_t1.75.fzp
+++ b/obsolete/LED-red-5mm_t1.75.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">red</property>
  </properties>

--- a/obsolete/LED-white-5mm (2).fzp
+++ b/obsolete/LED-white-5mm (2).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">white</property>
  </properties>
  <description>A generic white LED (~1.8V)</description>

--- a/obsolete/LED-white-5mm (3).fzp
+++ b/obsolete/LED-white-5mm (3).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">white</property>
   <property name="current" showInLabel="yes"></property>
  </properties>

--- a/obsolete/LED-white-5mm.fzp
+++ b/obsolete/LED-white-5mm.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">white</property>
  </properties>

--- a/obsolete/LED-white-5mm_t1.75.fzp
+++ b/obsolete/LED-white-5mm_t1.75.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">white</property>
  </properties>

--- a/obsolete/LED-yellow-5mm (2).fzp
+++ b/obsolete/LED-yellow-5mm (2).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">yellow</property>
  </properties>
  <description>A generic yellow LED (~1.8V)</description>

--- a/obsolete/LED-yellow-5mm (3).fzp
+++ b/obsolete/LED-yellow-5mm (3).fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="package">5 mm [THT]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">yellow</property>
   <property name="current" showInLabel="yes"></property>
  </properties>

--- a/obsolete/LED-yellow-5mm.fzp
+++ b/obsolete/LED-yellow-5mm.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">obsolete LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">yellow</property>
  </properties>

--- a/obsolete/LED-yellow-5mm_t1.75.fzp
+++ b/obsolete/LED-yellow-5mm_t1.75.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="obsoletepackage">T1.75 (5mm) [THT]</property>
-  <property name="family">LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="forward voltage">1.8V</property>
   <property name="color">yellow</property>
  </properties>

--- a/obsolete/LilyPad-Simple-v22.fzp
+++ b/obsolete/LilyPad-Simple-v22.fzp
@@ -99,7 +99,7 @@
 <tag>Simple</tag>
 </tags>
 <properties>
-<property name='family'>/obsolete/microcontroller board (lilypad)</property>
+<property name='family'>//obsolete//microcontroller board (lilypad)</property>
 <property name='type'>Arduino</property>
 <property name='Voltage'>3.3V</property>
 <property name='Digital Pins'>10</property>

--- a/obsolete/Lilypad_PowerSupply-v16.fzp
+++ b/obsolete/Lilypad_PowerSupply-v16.fzp
@@ -16,7 +16,7 @@ LilyPad is a wearable e-textile technology developed by Leah Buechley and cooper
 <tag>Supply</tag>
 </tags>
 <properties>
-<property name='family'>/obsolete/microcontroller board (lilypad)</property>
+<property name='family'>//obsolete//microcontroller board (lilypad)</property>
 <property name='Input Voltage'>1-5V</property>
 <property name='type'>Power Conditioning</property>
 <property name='Output Voltage'>5V</property>

--- a/obsolete/Micro-Python-pyboard-PYBv10b.fzp
+++ b/obsolete/Micro-Python-pyboard-PYBv10b.fzp
@@ -13,7 +13,7 @@
   <tag>STM32F405RG</tag>
  </tags>
  <properties>
-  <property name="family">/obsolete/Microcontroller</property>
+  <property name="family">//obsolete//Microcontroller</property>
   <property name="variant">variant 1</property>
   <property name="part number">PYBv10b</property>
   <property name="cpu">STM32F405RG 168MHz Cortex M4</property>

--- a/obsolete/NRF24L01_22e0249967228a8065b800b57589b75e_25.fzp
+++ b/obsolete/NRF24L01_22e0249967228a8065b800b57589b75e_25.fzp
@@ -18,7 +18,7 @@ p, li { white-space: pre-wrap; }
   <property name="part number"></property>
   <property name="layer"></property>
   <property name="variant">variant 2</property>
-  <property name="family">//obsolete// radio</property>
+  <property name="family">//obsolete//radio</property>
  </properties>
  <views>
   <breadboardView>

--- a/obsolete/PowerSupply-Lipo-v14.fzp
+++ b/obsolete/PowerSupply-Lipo-v14.fzp
@@ -27,7 +27,7 @@ Thin 0.8mm PCB</description>
 </tags>
 <properties>
 <property name='Input Voltage'>1-5V</property>
-<property name='family'>/obsolete/microcontroller board (lilypad)</property>
+<property name='family'>//obsolete//microcontroller board (lilypad)</property>
 <property name='type'>Power Conditioning</property>
 <property name='Output Voltage'>5V</property>
 <property name='Connector'>JST</property>

--- a/obsolete/RFM12b_HopeRF_Transceiver.fzp
+++ b/obsolete/RFM12b_HopeRF_Transceiver.fzp
@@ -7,7 +7,7 @@
     <date>2014-06-11</date>
     <tags/>
     <properties>
-        <property name="family">//obsolete// RFM12B Transreceiver</property>
+        <property name="family">//obsolete//RFM12B Transreceiver</property>
         <property name="part number"/>
     </properties>
     <description>RF Transceiver by Hope RF.  Well supported Arduino libraries are available.  Part is available in several frequencies (433MHz, 915MHz)...</description>

--- a/obsolete/RFM12b_HopeRF_old_Transceiver.fzp
+++ b/obsolete/RFM12b_HopeRF_old_Transceiver.fzp
@@ -7,7 +7,7 @@
     <date>2012-03-14</date>
     <tags/>
     <properties>
-        <property name="family">RFM12B Transreceiver /obsolete/</property>
+        <property name="family">//obsolete//RFM12B Transreceiver</property>
         <property name="part number"/>
     </properties>
     <description>RF Transceiver by Hope RF.  Well supported Arduino libraries are available.  Part is available in several frequencies (433MHz, 915MHz)...</description>

--- a/obsolete/RFM23BP_83dca743edce69d8624555bae587be66_7.fzp
+++ b/obsolete/RFM23BP_83dca743edce69d8624555bae587be66_7.fzp
@@ -49,7 +49,7 @@ p, li { white-space: pre-wrap; }
   <tag>ism</tag>
  </tags>
  <properties>
-  <property name="family">//(obsolete//lehoop</property>
+  <property name="family">//obsolete//lehoop</property>
   <property name="variant">variant 1</property>
   <property name="layer"></property>
   <property name="part number"></property>

--- a/obsolete/Raspberry Pi 3.fzp
+++ b/obsolete/Raspberry Pi 3.fzp
@@ -14,7 +14,7 @@
   <tag>RPi</tag>
  </tags>
  <properties>
-  <property name="family">cpu board (raspberry pi)</property>
+  <property name="family">//obsolete//cpu board (raspberry pi)</property>
   <property name="variant">Raspberry Pi 3</property>
   <property name="revision">RPI-3-V1.2</property>
   <property name="part number">RPI-3-V1.2</property>

--- a/obsolete/Raspberry_Pi(rev1).fzp
+++ b/obsolete/Raspberry_Pi(rev1).fzp
@@ -12,7 +12,7 @@
   <tag>Rev 1</tag>
  </tags>
  <properties>
-  <property name="family">/obsolte/CPU Board (Raspberry Pi)</property>
+  <property name="family">//obsolete//CPU Board (Raspberry Pi)</property>
   <property name="processor">Broadcom SoC BCM2835 ARMv6</property>
   <property name="variant">Raspberry Pi (Rev 01)</property>
  </properties>

--- a/obsolete/Raspberry_Pi(rev2).fzp
+++ b/obsolete/Raspberry_Pi(rev2).fzp
@@ -12,7 +12,7 @@
   <tag>Rev 2</tag>
  </tags>
  <properties>
-  <property name="family">/obsolte/CPU Board (Raspberry Pi)</property>
+  <property name="family">//obsolete//CPU Board (Raspberry Pi)</property>
   <property name="processor">Broadcom SoC BCM2835 ARMv6</property>
   <property name="variant">Raspberry Pi (Rev 02)</property>
  </properties>

--- a/obsolete/Raspberry_Pi.fzp
+++ b/obsolete/Raspberry_Pi.fzp
@@ -11,7 +11,7 @@
   <tag>RPi</tag>
  </tags>
  <properties>
-  <property name="family">/obsolete/CPU Board (Raspberry Pi)</property>
+  <property name="family">//obsolete//CPU Board (Raspberry Pi)</property>
   <property name="processor">Broadcom SoC BCM2835 ARMv6</property>
   <property name="variant">Raspberry Pi</property>
  </properties>

--- a/obsolete/Rotary_Encoder.fzp
+++ b/obsolete/Rotary_Encoder.fzp
@@ -12,7 +12,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">//obsolete// rotary encoder</property>	
+  <property name="family">//obsolete//rotary encoder</property>
   <property name="package">THT</property>
   <property name="type">ALPS STEC12E07</property>
  </properties>

--- a/obsolete/SMD_AD5206.fzp
+++ b/obsolete/SMD_AD5206.fzp
@@ -9,7 +9,7 @@
         <tag>SPI</tag>
     </tags>
     <properties>
-        <property name="family">IC-Poti</property>
+        <property name="family">//obsolete//IC-Poti</property>
     <property name="package">SO28 [SMD]</property>
     <property name="Maximum Resistance" showInLabel="yes">10k&#937;</property>
     </properties>

--- a/obsolete/SMD_LED_blue_0603.fzp
+++ b/obsolete/SMD_LED_blue_0603.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0603 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">blue</property>
   <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_blue_0805.fzp
+++ b/obsolete/SMD_LED_blue_0805.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0805 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">blue</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_blue_1206.fzp
+++ b/obsolete/SMD_LED_blue_1206.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">1206 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">blue</property>
      <property name="current" showInLabel="yes"/>
      </properties>

--- a/obsolete/SMD_LED_green_0603.fzp
+++ b/obsolete/SMD_LED_green_0603.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0603 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">green</property>
     <property name="current" showInLabel="yes"/>
     </properties>

--- a/obsolete/SMD_LED_green_0805.fzp
+++ b/obsolete/SMD_LED_green_0805.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0805 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">green</property>
     <property name="current" showInLabel="yes"/>
     </properties>

--- a/obsolete/SMD_LED_green_1206.fzp
+++ b/obsolete/SMD_LED_green_1206.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">1206 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">green</property>
   <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_red_0603.fzp
+++ b/obsolete/SMD_LED_red_0603.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0603 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">red</property>
    <property name="current" showInLabel="yes"/>
    </properties>

--- a/obsolete/SMD_LED_red_0805.fzp
+++ b/obsolete/SMD_LED_red_0805.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0805 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">red</property>
   <property name="current" showInLabel="yes"/>
   </properties>

--- a/obsolete/SMD_LED_red_1206.fzp
+++ b/obsolete/SMD_LED_red_1206.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">1206 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">red</property>
   <property name="current" showInLabel="yes"/>
   </properties>

--- a/obsolete/SMD_LED_white_0603.fzp
+++ b/obsolete/SMD_LED_white_0603.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0603 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">white</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_white_0805.fzp
+++ b/obsolete/SMD_LED_white_0805.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0805 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">white</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_white_1206.fzp
+++ b/obsolete/SMD_LED_white_1206.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">1206 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">white</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_yellow_0603.fzp
+++ b/obsolete/SMD_LED_yellow_0603.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0603 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">yellow</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_yellow_0805.fzp
+++ b/obsolete/SMD_LED_yellow_0805.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">0805 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">yellow</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_LED_yellow_1206.fzp
+++ b/obsolete/SMD_LED_yellow_1206.fzp
@@ -12,7 +12,7 @@
  <tag>SMD</tag></tags>
  <properties>
   <property name="package">1206 [SMD]</property>
-  <property name="family">obsolete_LED</property>
+  <property name="family">//obsolete//LED</property>
   <property name="color" showInLabel="yes">yellow</property>
     <property name="current" showInLabel="yes"/>
  </properties>

--- a/obsolete/SMD_mega2560.fzp
+++ b/obsolete/SMD_mega2560.fzp
@@ -16,7 +16,7 @@
 </tags>
 <properties>
 	<property name="version">Atmega2560</property>
-	<property name="family">//obsolete// Microcontroller</property>
+	<property name="family">//obsolete//Microcontroller</property>
 	<property name="type">Atmel AVR</property>
 	<property name="package">tqfp</property>
 	<property name="variant">tqfp100 14mm</property>

--- a/obsolete/Screw terminal.fzp
+++ b/obsolete/Screw terminal.fzp
@@ -6,7 +6,7 @@
     <date>2009-03-05</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Screw Terminal</property>
+        <property name="family">//obsolete//Screw Terminal</property>
         <property name="Pins">2</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>
     <property name="package">THT</property></properties>

--- a/obsolete/Screw terminal_3_5mm.fzp
+++ b/obsolete/Screw terminal_3_5mm.fzp
@@ -6,7 +6,7 @@
     <date>2009-06-08</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Screw Terminal</property>
+        <property name="family">//obsolete//Screw Terminal</property>
         <property name="Pins">2</property>
         <property name="Pin Spacing">3.5mm</property>
     <property name="package">THT</property></properties>

--- a/obsolete/TI Launchpad MSP430G2__ebb2b2673b63f5dd6fb32b9685c74b9e.fzp
+++ b/obsolete/TI Launchpad MSP430G2__ebb2b2673b63f5dd6fb32b9685c74b9e.fzp
@@ -12,7 +12,7 @@
         <tag>ti</tag>
     </tags>
     <properties>
-        <property name="family">/obsolet/MSP430</property>
+        <property name="family">//obsolete//MSP430</property>
     </properties>
     <description>The LaunchPad is an easy-to-use, affordable, and scalable introduction to the world of microcontrollers and the MSP430 family.
 

--- a/obsolete/WeMos-D1-mini-male-headers-above.fzp
+++ b/obsolete/WeMos-D1-mini-male-headers-above.fzp
@@ -12,7 +12,7 @@
   <tag>WiFi</tag>
  </tags>
  <properties>
-  <property name="family">WeMos D1 Mini</property>
+  <property name="family">//obsolete//WeMos D1 Mini</property>
   <property name="variant">variant 1</property>
   <property name="cpu">ESP-8266EX</property>
   <property name="headers">male above</property>

--- a/obsolete/accelerometer-adxl.fzp
+++ b/obsolete/accelerometer-adxl.fzp
@@ -11,7 +11,7 @@
 				<tag>breakout</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Accelerometers</property>
+        <property name="family">//obsolete//Accelerometers</property>
         <property name="axes">3 (x, y, z)</property>
 	<property name="chip">ADXL</property>
     </properties>

--- a/obsolete/arduino.fzp
+++ b/obsolete/arduino.fzp
@@ -13,7 +13,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino</property>
     </properties>

--- a/obsolete/arduino_Uno_Rev3.fzp
+++ b/obsolete/arduino_Uno_Rev3.fzp
@@ -20,7 +20,7 @@ Atmega 16U2 replace the 8U2.&#xd;&#xd;
   <tag>ATmega328</tag>
  </tags>
  <properties>
-  <property name="family">/obsolete/microcontroller board (arduino)</property>
+  <property name="family">//obsolete//microcontroller board (arduino)</property>
   <property name="part number"/>
   <property name="type">Arduino UNO (Rev3)</property>
  </properties>

--- a/obsolete/arduino_Yun(rev1).fzp
+++ b/obsolete/arduino_Yun(rev1).fzp
@@ -17,7 +17,7 @@ p, li { white-space: pre-wrap; }
   <tag>V1.0</tag>
  </tags>
  <properties>
-  <property name="family">microcontroller board (arduino)</property>
+  <property name="family">//obsolete//microcontroller board (arduino)</property>
   <property name="layer"></property>
   <property name="type">Arduino Yun</property>
   <property name="variant">rev 1</property>

--- a/obsolete/arduino_mega.fzp
+++ b/obsolete/arduino_mega.fzp
@@ -11,7 +11,7 @@
         <tag>controller</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Microcontroller Board (Arduino)</property>
+        <property name="family">//obsolete//Microcontroller Board (Arduino)</property>
         <property name="processor">ATmega</property>
         <property name="variant">Arduino Mega</property>
     </properties>

--- a/obsolete/artreeno.fzp
+++ b/obsolete/artreeno.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">135 x 126 mm</property>
-  <property name="family">obsolete PCB Tree</property>
+  <property name="family">//obsolete//PCB Tree</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.Tree.135x126mm</taxonomy>
  <description>Plain Vanilla 135 x 126 mm Circuit Tree Board</description>

--- a/obsolete/atmega168.fzp
+++ b/obsolete/atmega168.fzp
@@ -13,7 +13,7 @@
     </tags>
     <properties>
         <property name="version">Atmega168-20PU</property>
-        <property name="family">/obsolte/Microcontroller</property>
+        <property name="family">//obsolete//Microcontroller</property>
 				<property name="type">Atmel AVR</property>
    		<property name="package">DIP28 [THT]</property></properties>
     <description>Atmel ATmega168 microcontroller.  The hardware hacker favorite.</description>

--- a/obsolete/avr_isp_10_pin.fzp
+++ b/obsolete/avr_isp_10_pin.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="package">THT</property>
-        <property name="family">/obsolete/Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="form">♂ (shrouded male)</property>
         <property name="part number"></property>
         <property name="pin spacing">0.1in (2.54mm)</property>

--- a/obsolete/basic-diode.fzp
+++ b/obsolete/basic-diode.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Diode</property>
+  <property name="family">//obsolete//Diode</property>
   <property name="part">1N4001</property>
  <property name="package">THT</property></properties>
  <description>A generic rectifier diode</description>

--- a/obsolete/basic_ldr.fzp
+++ b/obsolete/basic_ldr.fzp
@@ -13,7 +13,7 @@
     </tags>
     <properties>
         <property name="resistance@ dark">300 kOhms@ 10 seconds</property>
-        <property name="family">obsolete Photo-Resistor</property>
+        <property name="family">//obsolete//Photo-Resistor</property>
         <property name="resistance@ luminance">16 kOhms@ 10 lux</property>
     <property name="package">THT</property></properties>
     <description>A generic light dependent resistor</description>

--- a/obsolete/basic_poti.fzp
+++ b/obsolete/basic_poti.fzp
@@ -12,7 +12,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-   <property name="family">Potentiometer</property>
+   <property name="family">//obsolete//Potentiometer</property>
    <property name="type">Trimmer Potentiometer</property>
    <property name="Maximum Resistance" showInLabel="yes">10k&#937;</property>
    <property name="Track">Linear</property>

--- a/obsolete/basic_pushbutton.fzp
+++ b/obsolete/basic_pushbutton.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Switch - 4 pin</property>
+  <property name="family">//obsolete//Switch - 4 pin</property>
   <property name="switching circuit">SPST</property>
   <property name="default state">Normally Open</property>
  <property name="package">THT</property></properties>

--- a/obsolete/basic_pushbutton_2lead_horizon.fzp
+++ b/obsolete/basic_pushbutton_2lead_horizon.fzp
@@ -10,7 +10,7 @@
  </tags>
  <properties>
   <property name="Default State">Normally Open</property>
-  <property name="family">obsolete Switch - 2 pin</property>
+  <property name="family">//obsolete//Switch - 2 pin</property>
   <property name="Switching Circuit">SPST</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.switches.pushbutton</taxonomy>

--- a/obsolete/basic_servo.fzp
+++ b/obsolete/basic_servo.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Servo</property>
+  <property name="family">//obsolete//Servo</property>
  </properties>
  <taxonomy>discreteParts.servo</taxonomy>
  <description>A generic servo.</description>

--- a/obsolete/basic_thermistor.fzp
+++ b/obsolete/basic_thermistor.fzp
@@ -12,7 +12,7 @@
   <tag>heat sensor</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Thermistor</property>
+  <property name="family">//obsolete//Thermistor</property>
   <property name="Resistance at 25°">10k Ω</property>
   <property name="Thermistor Type">NTC (Negative Temperature Coefficient)</property>
  <property name="package">THT</property></properties>

--- a/obsolete/basic_transistor_npn.fzp
+++ b/obsolete/basic_transistor_npn.fzp
@@ -13,7 +13,7 @@
  </tags>
  <properties>
   <property name="package">TO92 [THT]</property>
-  <property name="family">obsolete Bipolar Transistor</property>
+  <property name="family">//obsolete//Bipolar Transistor</property>
   <property name="doping">NPN</property>
  </properties>
  <description>A standard NPN-transistor</description>

--- a/obsolete/basic_transistor_pnp.fzp
+++ b/obsolete/basic_transistor_pnp.fzp
@@ -13,7 +13,7 @@
  </tags>
  <properties>
   <property name="package">TO92 [THT]</property>
-  <property name="family">obsolete Bipolar Transistor</property>
+  <property name="family">//obsolete//Bipolar Transistor</property>
   <property name="doping">pnp</property>
  </properties>
  <description>A standard pnp-transistor</description>

--- a/obsolete/battery-AA.fzp
+++ b/obsolete/battery-AA.fzp
@@ -10,7 +10,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Battery</property>
+        <property name="family">//obsolete//Battery</property>
         <property name="voltage" showInLabel="yes">3V</property>
     </properties>
     <description>Your standard 2x AA battery pack (3 Volts)</description>

--- a/obsolete/big_pot.fzp
+++ b/obsolete/big_pot.fzp
@@ -12,7 +12,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Potentiometer</property>
+  <property name="family">//obsolete//Potentiometer</property>
   <property name="type">Rotary Shaft Potentiometer</property>
 	<property name="size">Rotary - 16mm</property>
   <property name="Maximum Resistance" showInLabel="yes">100k&#937;</property>

--- a/obsolete/capacitor_ceramic_0_1nF.fzp
+++ b/obsolete/capacitor_ceramic_0_1nF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.1nF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/capacitor_ceramic_0_1uF.fzp
+++ b/obsolete/capacitor_ceramic_0_1uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.1&#181;F</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/capacitor_ceramic_1nF.fzp
+++ b/obsolete/capacitor_ceramic_1nF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1nF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/capacitor_ceramic_1uF.fzp
+++ b/obsolete/capacitor_ceramic_1uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1&#181;F</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/capacitor_ceramic_47nF.fzp
+++ b/obsolete/capacitor_ceramic_47nF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">47nF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/capacitor_ceramic_disk_0_01uF.fzp
+++ b/obsolete/capacitor_ceramic_disk_0_01uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.01&#181;F</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">500V</property>

--- a/obsolete/capacitor_ceramic_disk_0_1uF.fzp
+++ b/obsolete/capacitor_ceramic_disk_0_1uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.1&#181;F</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">500V</property>

--- a/obsolete/capacitor_ceramic_disk_1pF.fzp
+++ b/obsolete/capacitor_ceramic_disk_1pF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1pF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">500V</property>

--- a/obsolete/capacitor_ceramic_disk_220pF.fzp
+++ b/obsolete/capacitor_ceramic_disk_220pF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">220pF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">500V</property>

--- a/obsolete/capacitor_ceramic_disk_22pF.fzp
+++ b/obsolete/capacitor_ceramic_disk_22pF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">22pF</property>
   <property name="type">multilayer</property>
   <property name="Rated Voltage">500V</property>

--- a/obsolete/capacitor_tantalum_0_1uF.fzp
+++ b/obsolete/capacitor_tantalum_0_1uF.fzp
@@ -10,7 +10,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.1&#181;F</property>
   <property name="Capacitor Type">Tantalum</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/capacitor_tantalum_100uF.fzp
+++ b/obsolete/capacitor_tantalum_100uF.fzp
@@ -10,7 +10,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">100&#181;F</property>
   <property name="Capacitor Type">Tantalum</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/capacitor_tantalum_10uF.fzp
+++ b/obsolete/capacitor_tantalum_10uF.fzp
@@ -10,7 +10,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">10&#181;F</property>
   <property name="Capacitor Type">Tantalum</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/capacitor_tantalum_1uF.fzp
+++ b/obsolete/capacitor_tantalum_1uF.fzp
@@ -10,7 +10,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1&#181;F</property>
   <property name="Capacitor Type">Tantalum</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/ceramic_capacitor_0_01uF.fzp
+++ b/obsolete/ceramic_capacitor_0_01uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.01&#181;F</property>
   <property name="Capacitor Type">Ceramic</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/ceramic_capacitor_22pf.fzp
+++ b/obsolete/ceramic_capacitor_22pf.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">22pF</property>
   <property name="Capacitor Type">Ceramic</property>
   <property name="Rated Voltage">200V</property>

--- a/obsolete/ceramic_capacitor_basic_0_1uF.fzp
+++ b/obsolete/ceramic_capacitor_basic_0_1uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">0.1&#181;F</property>
   <property name="Capacitor Type">Ceramic</property>
   <property name="Rated Voltage">50V</property>

--- a/obsolete/controller_arduino_diecimila.fzp
+++ b/obsolete/controller_arduino_diecimila.fzp
@@ -12,7 +12,7 @@
 </tags>
 <properties>
   <property name="type">//obsolete//Microcontroller Board (Arduino)</property>
-  <property name="family">obsolete Microcontroller Board (deprecated)</property>
+  <property name="family">//obsolete//Microcontroller Board (deprecated)</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.controller</taxonomy>
  <description>The awesome Arduino Diecimila microcontroller (deprecated)</description>

--- a/obsolete/crystal (2).fzp
+++ b/obsolete/crystal (2).fzp
@@ -12,7 +12,7 @@
 	<tag>piezoelectric</tag>
     </tags>
     <properties>
-        <property name="family">obsolete oscillator</property>
+        <property name="family">//obsolete//oscillator</property>
         <property name="type">crystal</property>
         <property name="frequency">16 Mhz</property>
     <property name="package">THT</property></properties>

--- a/obsolete/crystal.fzp
+++ b/obsolete/crystal.fzp
@@ -12,7 +12,7 @@
 	<tag>piezoelectric</tag>
     </tags>
     <properties>
-        <property name="family">obsolete oscillator</property>
+        <property name="family">//obsolete//oscillator</property>
         <property name="type">crystal</property>
         <property name="frequency">16 Mhz</property>
     <property name="package">THT</property></properties>

--- a/obsolete/dc_motor.fzp
+++ b/obsolete/dc_motor.fzp
@@ -11,7 +11,7 @@
         <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete DC Motor</property>
+        <property name="family">//obsolete//DC Motor</property>
     </properties>
     <description>Your standard DC Motor</description>
     <views>

--- a/obsolete/diode_1N4001_300mil.fzp
+++ b/obsolete/diode_1N4001_300mil.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Diode</property>
+  <property name="family">//obsolete//Diode</property>
   <property name="part">1N4001</property>
  <property name="package">THT</property></properties>
  <description>A generic rectifier diode</description>

--- a/obsolete/diode_zener_0_5w_3_6v_300mil.fzp
+++ b/obsolete/diode_zener_0_5w_3_6v_300mil.fzp
@@ -11,7 +11,7 @@
   <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Diode</property>
+        <property name="family">//obsolete//Diode</property>
         <property name="type">Zener</property>
         <property name="power dissipation">0.5W</property>
         <property name="breakdown voltage">3.6V</property>

--- a/obsolete/diode_zener_1w_4_7v_300mil.fzp
+++ b/obsolete/diode_zener_1w_4_7v_300mil.fzp
@@ -11,7 +11,7 @@
   <tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Diode</property>
+        <property name="family">//obsolete//Diode</property>
         <property name="type">Zener</property>
         <property name="power dissipation">1W</property>
         <property name="breakdown voltage">4.7V</property>

--- a/obsolete/electrolytic_capacitor_1000uF.fzp
+++ b/obsolete/electrolytic_capacitor_1000uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1000&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_100uF.fzp
+++ b/obsolete/electrolytic_capacitor_100uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">100&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_10uF.fzp
+++ b/obsolete/electrolytic_capacitor_10uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">10&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_1uF.fzp
+++ b/obsolete/electrolytic_capacitor_1uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">1&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_220uF.fzp
+++ b/obsolete/electrolytic_capacitor_220uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">220&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_22uF.fzp
+++ b/obsolete/electrolytic_capacitor_22uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">22&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_4700uF.fzp
+++ b/obsolete/electrolytic_capacitor_4700uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">4700&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_470uF.fzp
+++ b/obsolete/electrolytic_capacitor_470uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">470&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_47uF.fzp
+++ b/obsolete/electrolytic_capacitor_47uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">47&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/electrolytic_capacitor_basic_10uF.fzp
+++ b/obsolete/electrolytic_capacitor_basic_10uF.fzp
@@ -10,7 +10,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">Capacitor</property>
+  <property name="family">//obsolete//Capacitor</property>
   <property name="Capacitance">10&#181;F</property>
   <property name="Capacitor Type">Electrolytic</property>
   <property name="Rated Voltage">35V</property>

--- a/obsolete/generic-female-header-rounded_10.fzp
+++ b/obsolete/generic-female-header-rounded_10.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">10</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_11.fzp
+++ b/obsolete/generic-female-header-rounded_11.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">11</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_12.fzp
+++ b/obsolete/generic-female-header-rounded_12.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">12</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_14.fzp
+++ b/obsolete/generic-female-header-rounded_14.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">14</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_16.fzp
+++ b/obsolete/generic-female-header-rounded_16.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">16</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_18.fzp
+++ b/obsolete/generic-female-header-rounded_18.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">18</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_2.fzp
+++ b/obsolete/generic-female-header-rounded_2.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">2</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_20.fzp
+++ b/obsolete/generic-female-header-rounded_20.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">20</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_3.fzp
+++ b/obsolete/generic-female-header-rounded_3.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">3</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_4.fzp
+++ b/obsolete/generic-female-header-rounded_4.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">4</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_5.fzp
+++ b/obsolete/generic-female-header-rounded_5.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">5</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_6.fzp
+++ b/obsolete/generic-female-header-rounded_6.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">6</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_7.fzp
+++ b/obsolete/generic-female-header-rounded_7.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">7</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_8.fzp
+++ b/obsolete/generic-female-header-rounded_8.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">8</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header-rounded_9.fzp
+++ b/obsolete/generic-female-header-rounded_9.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">9</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_10.fzp
+++ b/obsolete/generic-female-header_10.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">10</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_11.fzp
+++ b/obsolete/generic-female-header_11.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">11</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_12.fzp
+++ b/obsolete/generic-female-header_12.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">12</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_14.fzp
+++ b/obsolete/generic-female-header_14.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">14</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_16.fzp
+++ b/obsolete/generic-female-header_16.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">16</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_18.fzp
+++ b/obsolete/generic-female-header_18.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">18</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_2.fzp
+++ b/obsolete/generic-female-header_2.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">2</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_20.fzp
+++ b/obsolete/generic-female-header_20.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">20</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_3.fzp
+++ b/obsolete/generic-female-header_3.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">3</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_4.fzp
+++ b/obsolete/generic-female-header_4.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">4</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_5.fzp
+++ b/obsolete/generic-female-header_5.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">5</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_6.fzp
+++ b/obsolete/generic-female-header_6.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">6</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_7.fzp
+++ b/obsolete/generic-female-header_7.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">7</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_8.fzp
+++ b/obsolete/generic-female-header_8.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">8</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-female-header_9.fzp
+++ b/obsolete/generic-female-header_9.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">9</property>
         <property name="Gender">♀</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_10.fzp
+++ b/obsolete/generic-male-header_10.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">10</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_11.fzp
+++ b/obsolete/generic-male-header_11.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">11</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_12.fzp
+++ b/obsolete/generic-male-header_12.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">12</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_14.fzp
+++ b/obsolete/generic-male-header_14.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">14</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_16.fzp
+++ b/obsolete/generic-male-header_16.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">16</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_18.fzp
+++ b/obsolete/generic-male-header_18.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">18</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_2.fzp
+++ b/obsolete/generic-male-header_2.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">2</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_20.fzp
+++ b/obsolete/generic-male-header_20.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">20</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_3.fzp
+++ b/obsolete/generic-male-header_3.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">3</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_4.fzp
+++ b/obsolete/generic-male-header_4.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">4</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_5.fzp
+++ b/obsolete/generic-male-header_5.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">5</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_6.fzp
+++ b/obsolete/generic-male-header_6.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">6</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_7.fzp
+++ b/obsolete/generic-male-header_7.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">7</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_8.fzp
+++ b/obsolete/generic-male-header_8.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">8</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/generic-male-header_9.fzp
+++ b/obsolete/generic-male-header_9.fzp
@@ -6,7 +6,7 @@
     <date>2009-10-01</date>
     <tags/>
     <properties>
-        <property name="family">obsolete Pin Header</property>
+        <property name="family">//obsolete//Pin Header</property>
         <property name="Pins">9</property>
         <property name="Gender">♂</property>
         <property name="Pin Spacing">0.1in (2.54mm)</property>

--- a/obsolete/inductor.fzp
+++ b/obsolete/inductor.fzp
@@ -9,7 +9,7 @@
         <tag>coil</tag>
     </tags>
     <properties>
-        <property name="family">obsolete air-core inductor</property>
+        <property name="family">//obsolete//air-core inductor</property>
     <property name="package">400 mil [THT]</property>
      <property name="inductance" showInLabel="yes">10nH</property>
      </properties>

--- a/obsolete/intel_edison_minibreakout-bottom.fzp
+++ b/obsolete/intel_edison_minibreakout-bottom.fzp
@@ -20,7 +20,7 @@ The tiny Edison fits nicely onto a breakout board - sort of like a tiny IoT spar
 <tag>EDISON_minibreakout</tag>
 </tags>
 <properties>
-  <property name="family">/obsolete/microcontroller board (intel)</property>
+  <property name="family">//obsolete//microcontroller board (intel)</property>
   <property name="part number">
   </property>
   <property name="type">Edison miniBreakout</property>

--- a/obsolete/intel_edison_minibreakout.fzp
+++ b/obsolete/intel_edison_minibreakout.fzp
@@ -20,7 +20,7 @@ The tiny Edison fits nicely onto a breakout board - sort of like a tiny IoT spar
 <tag>EDISON_minibreakout</tag>
 </tags>
 <properties>
-  <property name="family">/obosolete/microcontroller board (intel)</property>
+  <property name="family">//obsolete//microcontroller board (intel)</property>
   <property name="part number">
   </property>
   <property name="type">Edison miniBreakout</property>

--- a/obsolete/lcd-screen.fzp
+++ b/obsolete/lcd-screen.fzp
@@ -13,7 +13,7 @@
         <tag>screen</tag>
     </tags>
     <properties>
-        <property name="family">Display</property>
+        <property name="family">//obsolete//Display</property>
         <property name="type">Character</property>
         <property name="pins">16</property>
     </properties>

--- a/obsolete/led-rgb-4pin-anode.fzp
+++ b/obsolete/led-rgb-4pin-anode.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="package">5 mm [THT]</property>
-        <property name="family">obsolete LED</property>
+        <property name="family">//obsolete//LED</property>
         <property name="color" showInLabel="yes">RGB</property>
     </properties>
     <description>A 5mm tri-color LED with red, green and blue inside.</description>

--- a/obsolete/led-rgb-6pin.fzp
+++ b/obsolete/led-rgb-6pin.fzp
@@ -12,7 +12,7 @@
     </tags>
     <properties>
 	<property name="package">5 mm [THT]</property>
-	<property name="family">obsolete LED</property>
+	<property name="family">//obsolete//LED</property>
 	<property name="color" showInLabel="yes">RGBB</property>
     </properties>
     <description>A full-color LED, combined from four colors RGBB.</description>

--- a/obsolete/mystery_part1.fzp
+++ b/obsolete/mystery_part1.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">1</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part10.fzp
+++ b/obsolete/mystery_part10.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">10</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part11.fzp
+++ b/obsolete/mystery_part11.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">11</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part12.fzp
+++ b/obsolete/mystery_part12.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">12</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part14.fzp
+++ b/obsolete/mystery_part14.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">14</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part16.fzp
+++ b/obsolete/mystery_part16.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">16</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part18.fzp
+++ b/obsolete/mystery_part18.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">18</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part2.fzp
+++ b/obsolete/mystery_part2.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">2</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part20.fzp
+++ b/obsolete/mystery_part20.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">20</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part3.fzp
+++ b/obsolete/mystery_part3.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">3</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part4.fzp
+++ b/obsolete/mystery_part4.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">4</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part5.fzp
+++ b/obsolete/mystery_part5.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">5</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part6.fzp
+++ b/obsolete/mystery_part6.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">6</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part7.fzp
+++ b/obsolete/mystery_part7.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">7</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part8.fzp
+++ b/obsolete/mystery_part8.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">8</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/mystery_part9.fzp
+++ b/obsolete/mystery_part9.fzp
@@ -9,7 +9,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Mystery Part</property>
+  <property name="family">//obsolete//Mystery Part</property>
   <property name="pins">9</property>
   <property name="footprint">100 mil jumper</property>
   <property name="chip label">?</property>

--- a/obsolete/pcb-plain-100x160.fzp
+++ b/obsolete/pcb-plain-100x160.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">100 x 160 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.100x160mm</taxonomy>
  <description>Plain Vanilla 100 x 160 mm Circuit Board</description>

--- a/obsolete/pcb-plain-150x200.fzp
+++ b/obsolete/pcb-plain-150x200.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">150 x 200 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.150x200mm</taxonomy>
  <description>Plain Vanilla 150 x 200 mm Circuit Board</description>

--- a/obsolete/pcb-plain-200x300.fzp
+++ b/obsolete/pcb-plain-200x300.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">200 x 300 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.200x300mm</taxonomy>
  <description>Plain Vanilla 200 x 300 mm Circuit Board</description>

--- a/obsolete/pcb-plain-250x250.fzp
+++ b/obsolete/pcb-plain-250x250.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">250 x 250 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.250x250mm</taxonomy>
  <description>Plain Vanilla 250 x 250 mm Circuit Board</description>

--- a/obsolete/pcb-plain-60x100.fzp
+++ b/obsolete/pcb-plain-60x100.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">60 x 100 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.60x100mm</taxonomy>
  <description>Plain Vanilla 60 x 100 mm Circuit Board</description>

--- a/obsolete/pcb-plain-75x100.fzp
+++ b/obsolete/pcb-plain-75x100.fzp
@@ -12,7 +12,7 @@
  </tags>
  <properties>
   <property name="Size">75 x 100 mm</property>
-  <property name="family">obsolete Plain PCB</property>
+  <property name="family">//obsolete//Plain PCB</property>
  <property name="package">THT</property></properties>
  <taxonomy>discreteParts.pcb.plain.75x100mm</taxonomy>
  <description>Plain Vanilla 75 x 100 mm Circuit Board</description>

--- a/obsolete/pot-slider.fzp
+++ b/obsolete/pot-slider.fzp
@@ -13,7 +13,7 @@
 				<tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Potentiometer</property>
+        <property name="family">//obsolete//Potentiometer</property>
         <property name="track">Linear</property>
         <property name="type">Slide Potentiometer</property>
         <property name="maximum resistance" showInLabel="yes">100k&#937;</property>

--- a/obsolete/pot-small.fzp
+++ b/obsolete/pot-small.fzp
@@ -12,7 +12,7 @@
 				<tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Potentiometer</property>
+        <property name="family">//obsolete//Potentiometer</property>
         <property name="track">Linear</property>
         <property name="type">Rotary Shaft Potentiometer</property>
         <property name="size">Rotary - 9mm</property>

--- a/obsolete/pot-small2.fzp
+++ b/obsolete/pot-small2.fzp
@@ -12,7 +12,7 @@
 				<tag>fritzing core</tag>
     </tags>
     <properties>
-        <property name="family">/obsolete/Potentiometer</property>
+        <property name="family">//obsolete//Potentiometer</property>
         <property name="track">Linear</property>
         <property name="type">Rotary Shaft Potentiometer</property>
         <property name="size">Rotary - 9mm</property>

--- a/obsolete/pot_trimmer_6mm.fzp
+++ b/obsolete/pot_trimmer_6mm.fzp
@@ -12,7 +12,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-   <property name="family">obsolete Potentiometer</property>
+   <property name="family">//obsolete//Potentiometer</property>
    <property name="type">Trimmer Potentiometer</property>
    <property name="Maximum Resistance" showInLabel="yes">10k&#937;</property>
    <property name="Track">Linear</property>

--- a/obsolete/prefix0000_c370f033d3f6e718f3cd68009db820d9_5.fzp
+++ b/obsolete/prefix0000_c370f033d3f6e718f3cd68009db820d9_5.fzp
@@ -16,7 +16,7 @@ p, li { white-space: pre-wrap; }
  </tags>
  <properties>
   <property name="variant">variant 1</property>
-  <property name="family">//obosolete//microsd</property>
+  <property name="family">//obsolete//microsd</property>
   <property name="chip">PG6SD</property>
  </properties>
  <views>

--- a/obsolete/reed switch.fzp
+++ b/obsolete/reed switch.fzp
@@ -9,7 +9,7 @@
         <tag>magnet</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Reed Switch</property>
+        <property name="family">//obsolete//Reed Switch</property>
     <property name="package">THT</property></properties>
     <description>Reed switch</description>
     <views>

--- a/obsolete/resistor_10.fzp
+++ b/obsolete/resistor_10.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">10Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_100.fzp
+++ b/obsolete/resistor_100.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">100Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_100_mini.fzp
+++ b/obsolete/resistor_100_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">100Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_100k.fzp
+++ b/obsolete/resistor_100k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">100kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_100k_mini.fzp
+++ b/obsolete/resistor_100k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">100kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_10_mini.fzp
+++ b/obsolete/resistor_10_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">10Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_10k.fzp
+++ b/obsolete/resistor_10k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">10kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_10k_mini.fzp
+++ b/obsolete/resistor_10k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">10kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_15.fzp
+++ b/obsolete/resistor_15.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">15Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_150.fzp
+++ b/obsolete/resistor_150.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">150Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_150_mini.fzp
+++ b/obsolete/resistor_150_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">150Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_150k.fzp
+++ b/obsolete/resistor_150k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">150kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_150k_mini.fzp
+++ b/obsolete/resistor_150k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">150kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_15_mini.fzp
+++ b/obsolete/resistor_15_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">15Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_15k.fzp
+++ b/obsolete/resistor_15k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">15kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_15k_mini.fzp
+++ b/obsolete/resistor_15k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">15kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1M.fzp
+++ b/obsolete/resistor_1M.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1MΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1M_mini.fzp
+++ b/obsolete/resistor_1M_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1MΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1_5k.fzp
+++ b/obsolete/resistor_1_5k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1.5kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1_5k_mini.fzp
+++ b/obsolete/resistor_1_5k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1.5kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1k.fzp
+++ b/obsolete/resistor_1k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_1k_mini.fzp
+++ b/obsolete/resistor_1k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">1kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_22.fzp
+++ b/obsolete/resistor_22.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">22Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_220.fzp
+++ b/obsolete/resistor_220.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">220Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_220_mini.fzp
+++ b/obsolete/resistor_220_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">220Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_220k.fzp
+++ b/obsolete/resistor_220k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">220kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_220k_mini.fzp
+++ b/obsolete/resistor_220k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">220kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_22_mini.fzp
+++ b/obsolete/resistor_22_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">22Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_22k.fzp
+++ b/obsolete/resistor_22k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">22kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_22k_mini.fzp
+++ b/obsolete/resistor_22k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">22kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_27k.fzp
+++ b/obsolete/resistor_27k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">27kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_27k_mini.fzp
+++ b/obsolete/resistor_27k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">27kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_2_2k.fzp
+++ b/obsolete/resistor_2_2k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">2.2kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_2_2k_mini.fzp
+++ b/obsolete/resistor_2_2k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">2.2kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_33.fzp
+++ b/obsolete/resistor_33.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">33Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_330.fzp
+++ b/obsolete/resistor_330.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">330Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_330_mini.fzp
+++ b/obsolete/resistor_330_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">330Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_330k.fzp
+++ b/obsolete/resistor_330k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">330kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_330k_mini.fzp
+++ b/obsolete/resistor_330k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">330kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_33_mini.fzp
+++ b/obsolete/resistor_33_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">33Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_33k.fzp
+++ b/obsolete/resistor_33k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">33kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_33k_mini.fzp
+++ b/obsolete/resistor_33k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">33kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_3_3k.fzp
+++ b/obsolete/resistor_3_3k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">3.3kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_3_3k_mini.fzp
+++ b/obsolete/resistor_3_3k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">3.3kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_47.fzp
+++ b/obsolete/resistor_47.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">47Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_470.fzp
+++ b/obsolete/resistor_470.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">470Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_470_mini.fzp
+++ b/obsolete/resistor_470_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">470Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_470k.fzp
+++ b/obsolete/resistor_470k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">470kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_470k_mini.fzp
+++ b/obsolete/resistor_470k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">470kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_47_mini.fzp
+++ b/obsolete/resistor_47_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">47Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_47k.fzp
+++ b/obsolete/resistor_47k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">47kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_47k_mini.fzp
+++ b/obsolete/resistor_47k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">47kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_4_7k.fzp
+++ b/obsolete/resistor_4_7k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">4.7kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_4_7k_mini.fzp
+++ b/obsolete/resistor_4_7k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">4.7kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_68.fzp
+++ b/obsolete/resistor_68.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">68Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_680.fzp
+++ b/obsolete/resistor_680.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">680Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_680_mini.fzp
+++ b/obsolete/resistor_680_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">680Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_680k.fzp
+++ b/obsolete/resistor_680k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">680kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_680k_mini.fzp
+++ b/obsolete/resistor_680k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">680kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_68_mini.fzp
+++ b/obsolete/resistor_68_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">68Ω</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_68k.fzp
+++ b/obsolete/resistor_68k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">68kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_68k_mini.fzp
+++ b/obsolete/resistor_68k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">68kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_6_8k.fzp
+++ b/obsolete/resistor_6_8k.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">6.8kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">400 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resistor_6_8k_mini.fzp
+++ b/obsolete/resistor_6_8k_mini.fzp
@@ -11,7 +11,7 @@
     </tags>
     <properties>
         <property name="Resistance">6.8kΩ</property>
-        <property name="family">obsolete Resistor</property>
+        <property name="family">//obsolete//Resistor</property>
       <property name="Rated Power">0.25 watt</property>
       <property name="footprint">300 mil</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resonator-2pin.fzp
+++ b/obsolete/resonator-2pin.fzp
@@ -11,7 +11,7 @@
         <tag>ceramic</tag>
     </tags>
     <properties>
-        <property name="family">obsolete oscillator</property>
+        <property name="family">//obsolete//oscillator</property>
         <property name="type">ceramic resonator</property>
         <property name="frequency" showInLabel="yes">16 Mhz</property>
     <property name="package">THT</property></properties>

--- a/obsolete/resonator-3pin.fzp
+++ b/obsolete/resonator-3pin.fzp
@@ -11,7 +11,7 @@
         <tag>ceramic</tag>
     </tags>
     <properties>
-        <property name="family">obsolete oscillator</property>
+        <property name="family">//obsolete//oscillator</property>
         <property name="type">ceramic resonator with capacitor</property>
         <property name="frequency" showInLabel="yes">16 Mhz</property>
     <property name="package">THT</property></properties>

--- a/obsolete/sparkfun-discretesemi-diode-1n4148.fzp
+++ b/obsolete/sparkfun-discretesemi-diode-1n4148.fzp
@@ -14,7 +14,7 @@ These are standard reverse protection diodes and small signal diodes. SMA packag
 </tags>
 <properties>
 <property name="package">diode-1n4148</property>
-<property name="family">/obosolete/sparkfun Diode</property>
+<property name="family">//obsolete//sparkfun Diode</property>
 <property name="variant">1n4148</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-discretesemi-diode-hv.fzp
+++ b/obsolete/sparkfun-discretesemi-diode-hv.fzp
@@ -14,7 +14,7 @@ These are standard reverse protection diodes and small signal diodes. SMA packag
 </tags>
 <properties>
 <property name="package">diode-hv</property>
-<property name="family">/obosolete/sparkfun Diode</property>
+<property name="family">//obsolete//sparkfun Diode</property>
 <property name="variant">hv</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-discretesemi-diode-pth.fzp
+++ b/obsolete/sparkfun-discretesemi-diode-pth.fzp
@@ -14,7 +14,7 @@ These are standard reverse protection diodes and small signal diodes. SMA packag
 </tags>
 <properties>
 <property name="package">diode-1n4001</property>
-<property name="family">/obosolete/sparkfun Diode</property>
+<property name="family">//obsolete//sparkfun Diode</property>
 <property name="variant">pth</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-electromechanical-battery-2-aa.fzp
+++ b/obsolete/sparkfun-electromechanical-battery-2-aa.fzp
@@ -13,7 +13,7 @@
 </tags>
 <properties>
 <property name="package">battery-aa</property>
-<property name="family">//obsolete// sparkfun Battery Holder</property>
+<property name="family">//obsolete//sparkfun Battery Holder</property>
 <property name="variant">aa</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-electromechanical-battery-2-aaa.fzp
+++ b/obsolete/sparkfun-electromechanical-battery-2-aaa.fzp
@@ -13,7 +13,7 @@
 </tags>
 <properties>
 <property name="package">battery-aaa</property>
-<property name="family">sparkfun Battery Holder</property>
+<property name="family">//obsolete//sparkfun Battery Holder</property>
 <property name="variant">aaa</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-electromechanical-battery-aa-kit.fzp
+++ b/obsolete/sparkfun-electromechanical-battery-aa-kit.fzp
@@ -14,7 +14,7 @@ Various common sizes : AA, AAA, 20mm coin cell and 12mm coin cell.</description>
 </tags>
 <properties>
 <property name="package">battery-aa-kit</property>
-<property name="family">//obsolete// sparkfun Battery Holder</property>
+<property name="family">//obsolete//sparkfun Battery Holder</property>
 <property name="variant">aa-kit</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-electromechanical-battery-aaa.fzp
+++ b/obsolete/sparkfun-electromechanical-battery-aaa.fzp
@@ -14,7 +14,7 @@ Various common sizes : AA, AAA, 20mm coin cell and 12mm coin cell.</description>
 </tags>
 <properties>
 <property name="package">battery-aaa</property>
-<property name="family">//obsolete// sparkfun Battery Holder</property>
+<property name="family">//obsolete//sparkfun Battery Holder</property>
 <property name="variant">aaa</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-led-led-10mm.fzp
+++ b/obsolete/sparkfun-led-led-10mm.fzp
@@ -14,7 +14,7 @@ Standard schematic elements and footprints for 5mm, 3mm, 1206, and 0603 sized LE
 </tags>
 <properties>
 <property name="package">led10mm</property>
-<property name="family">//obsolete// sparkfun LED</property>
+<property name="family">//obsolete//sparkfun LED</property>
 <property name="variant">10mm</property>
 </properties>
 <views>

--- a/obsolete/sparkfun-passives-resistor-0402-res.fzp
+++ b/obsolete/sparkfun-passives-resistor-0402-res.fzp
@@ -14,7 +14,7 @@ Basic schematic elements and footprints for 0603, 1206, and PTH resistors.</desc
 </tags>
 <properties>
 <property name="package">0402 [SMD]</property>
-<property name="family">//obosolete// Resistor</property>
+<property name="family">//obsolete//Resistor</property>
         <property name="Resistance" showInLabel="yes">220</property>
       <property name="power" showInLabel="yes"/>
       <property name="tolerance" showInLabel="yes">&#177;5%</property>

--- a/obsolete/sparkfun-passives-resistor-2010.fzp
+++ b/obsolete/sparkfun-passives-resistor-2010.fzp
@@ -14,7 +14,7 @@ Basic schematic elements and footprints for 0603, 1206, and PTH resistors.</desc
 </tags>
 <properties>
 <property name="package">2010 [SMD]</property>
-<property name="family">//obosolete// Resistor</property>
+<property name="family">//obsolete//Resistor</property>
         <property name="Resistance" showInLabel="yes">220</property>
       <property name="power" showInLabel="yes"/>
       <property name="tolerance" showInLabel="yes">&#177;5%</property>

--- a/obsolete/sparkfun-passives-resistor-2512.fzp
+++ b/obsolete/sparkfun-passives-resistor-2512.fzp
@@ -14,7 +14,7 @@ Basic schematic elements and footprints for 0603, 1206, and PTH resistors.</desc
 </tags>
 <properties>
 <property name="package">2512 [SMD]</property>
-<property name="family">//obosolete// Resistor</property>
+<property name="family">//obsolete//Resistor</property>
         <property name="Resistance" showInLabel="yes">220</property>
       <property name="power" showInLabel="yes"/>
       <property name="tolerance" showInLabel="yes">&#177;5%</property>

--- a/obsolete/sparkfun-sensors-qrb1114-.fzp
+++ b/obsolete/sparkfun-sensors-qrb1114-.fzp
@@ -27,7 +27,7 @@ object passes within its field of view. The area of the optimum response approxi
 </tags>
 <properties>
 <property name="package">qrb1114-side</property>
-<property name="family">sparkfun Reflective Object Sensor</property>
+<property name="family">//obsolete//sparkfun Reflective Object Sensor</property>
 </properties>
 <views>
 <breadboardView>

--- a/obsolete/starter-poti-small.fzp
+++ b/obsolete/starter-poti-small.fzp
@@ -13,7 +13,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-  <property name="family">/obsolete/potentiometer</property>
+  <property name="family">//obsolete//potentiometer</property>
   <property name="track">Linear</property>
   <property name="type">Rotary Shaft Potentiometer</property>
   <property name="size">Rotary - 9mm</property>

--- a/obsolete/stepper_motor_bipolar.fzp
+++ b/obsolete/stepper_motor_bipolar.fzp
@@ -13,7 +13,7 @@
         <property name="current">0.28 A</property>
         <property name="shaft">5 mm diameter / 33 mm length</property>
         <property name="size">42.3 x 42.3 x 37.0 mm</property>
-        <property name="family">obsolete Stepper Motor</property>
+        <property name="family">//obsolete//Stepper Motor</property>
         <property name="Stepper Type">Bipolar</property>
         <property name="phase">2</property>
         <property name="step angle">1.8</property>

--- a/obsolete/stepper_motor_unipolar.fzp
+++ b/obsolete/stepper_motor_unipolar.fzp
@@ -9,7 +9,7 @@
         <tag>Stepper Motor</tag>
     </tags>
     <properties>
-        <property name="family">obsolete Stepper Motor</property>
+        <property name="family">//obsolete//Stepper Motor</property>
         <property name="Stepper Type">Unipolar</property>
     </properties>
     <description>A basic unipolar stepper motor</description>

--- a/obsolete/stereo-jack-3_5mm.fzp
+++ b/obsolete/stereo-jack-3_5mm.fzp
@@ -16,7 +16,7 @@
         <property name="package">PG203J [THT]</property>
         <property name="channels">Stereo</property>
         <property name="size">3.5 mm</property>
-        <property name="family">Audio Connector</property>
+        <property name="family">//obsolete//Audio Connector</property>
     </properties>
     <description>Stereo Jack 3.5mm</description>
     <views>

--- a/obsolete/thermistor_300mil.fzp
+++ b/obsolete/thermistor_300mil.fzp
@@ -12,7 +12,7 @@
   <tag>heat sensor</tag>
  </tags>
  <properties>
-  <property name="family">obsolete Thermistor</property>
+  <property name="family">//obsolete//Thermistor</property>
   <property name="Resistance at 25°">10k&#937;</property>
   <property name="Thermistor Type">NTC (Negative Temperature Coefficient)</property>
  <property name="package">THT</property></properties>

--- a/obsolete/transistor_signal_NPN_TO92.fzp
+++ b/obsolete/transistor_signal_NPN_TO92.fzp
@@ -13,7 +13,7 @@
  </tags>
  <properties>
   <property name="package">TO92 [THT]</property>
-  <property name="family">//obsolete// Bipolar Transistor</property>
+  <property name="family">//obsolete//Bipolar Transistor</property>
   <property name="type">NPN (EBC)</property>
  </properties>
  <description>A standard NPN-transistor</description>

--- a/obsolete/transistor_signal_PNP_TO92.fzp
+++ b/obsolete/transistor_signal_PNP_TO92.fzp
@@ -13,7 +13,7 @@
  </tags>
  <properties>
   <property name="package">TO92 [THT]</property>
-  <property name="family">//obsolete// Bipolar Transistor</property>
+  <property name="family">//obsolete//Bipolar Transistor</property>
   <property name="type">PNP</property>
  </properties>
  <description>A standard PNP signal transistor</description>

--- a/obsolete/trimpot_meggitt_pih.fzp
+++ b/obsolete/trimpot_meggitt_pih.fzp
@@ -12,7 +12,7 @@
   <tag>fritzing core</tag>
  </tags>
  <properties>
-   <property name="family">obsolete Potentiometer</property>
+   <property name="family">//obsolete//Potentiometer</property>
    <property name="type">Trimmer Potentiometer</property>
    <property name="Maximum Resistance">10kΩ</property>
    <property name="Track">Linear</property>


### PR DESCRIPTION
While researching the obsoleting process, I did a grep, output to spreadsheet, filter, sort, and found 14 different variations in the 363 current obsolete files.  13 different prefixes, and 41 obsolete fzp files without any tag that I could see.  The prefixes (and counts) that I found were:

```text
$ grep -Ei "property.*family" obsolete/*.fzp

"obsolete "	181
"/obsolete/"	25
"//obsolete// "	10
"//obsolete//"	69
"//oboslete//"	1
"/oboslete/"	1
"/obsolte/"	3
"//obosolete// "	3
"//obosolete//"	3
"/obosolete/"	4
"obsolete_"	20
"/obsolet/"	1
"//(obsolete//"	1
```

The most recent cases I found in the logs (which only go back a couple of years) use the `"//obsolete//"` prefix.
```text
$ git log --oneline svg/obsolete/
$ git show «id»
```

This pull request changes all of the obsolete part files to have the same `"//obsolete//"` prefix on the family text.

Most of the processing was done with a few lines of sed.
```bash
sed -E -i '/property.*family/s\>[/(]*(oboslete|obosolete|obsolet|obsolete_|obsolete|obsolte)[_/]*[ ]*\>//obsolete//\' obsolete/*
sed -E -i '/property.*family/s\[ \t]*$\\' obsolete/*
sed -E -i '/property.*family/s^>([a-zA-Z])^>//obsolete//\1^' obsolete/*
```
Had to manually edit obsolete/RFM12b_HopeRF_old_Transceiver.fzp, because the obsolete marker there was at the end instead of the beginning of the family text.
