### PR TITLE
Fix SVGs with missing xmlns attribute.

### DIFF
--- a/svg/core/icon/555timericon.svg
+++ b/svg/core/icon/555timericon.svg
@@ -6,7 +6,8 @@
    x="0px"
    y="0px"
    width="32px"
-   height="32px">
+   height="32px"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="icon"
      transform="matrix(0.8,0,0,0.8,0,2.8)">

--- a/svg/core/icon/LED-rgb-5mmicon.svg
+++ b/svg/core/icon/LED-rgb-5mmicon.svg
@@ -6,7 +6,8 @@
    width="32"
    height="32"
    viewBox="-0.5 -2.125 39 53"
-   id="svg2">
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg">
 <g
    id="g2408"
    transform="matrix(1,0,0,1.0000108,0,-1.0815625)"><path

--- a/svg/core/icon/basic_fsr.svg
+++ b/svg/core/icon/basic_fsr.svg
@@ -4,7 +4,8 @@
    baseProfile="tiny"
    width="32"
    height="32"
-   id="svg2">
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="icon"
      style="display:inline"

--- a/svg/core/icon/basic_pbutton.svg
+++ b/svg/core/icon/basic_pbutton.svg
@@ -4,7 +4,8 @@
    baseProfile="tiny"
    width="32"
    height="32"
-   id="svg2">
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="icon"
      style="display:inline"

--- a/svg/core/icon/basic_pbutton_2leg_horizon.svg
+++ b/svg/core/icon/basic_pbutton_2leg_horizon.svg
@@ -3,7 +3,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1"
 	 id="svg2" x="0px" y="0px" width="32px" height="32px"
-	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
 <rect id="connector0pin" x="26.565" y="14.234" fill="#8C8C8C" width="5.421" height="2.9"/>
 <rect id="connector1pin" x="0.076" y="14.275" fill="#8C8C8C" width="5.744" height="2.901"/>
 <path id="path21_8_" fill="#474747" d="M5.264,20.832c-1.101,0-1.521-0.391-1.524-0.869v-5.312

--- a/svg/core/icon/basic_photo_transistoricon.svg
+++ b/svg/core/icon/basic_photo_transistoricon.svg
@@ -4,7 +4,8 @@
    baseProfile="tiny"
    width="32"
    height="32"
-   id="svg2">
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="icon"
      style="display:inline"

--- a/svg/core/icon/basic_relay.svg
+++ b/svg/core/icon/basic_relay.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><svg baseProfile="tiny" height="32" id="svg2" version="1.0" width="32" x="0px" xml:space="preserve" y="0px">
+<?xml version="1.0" encoding="UTF-8"?><svg baseProfile="tiny" height="32" id="svg2" version="1.0" width="32" x="0px" xml:space="preserve" y="0px" xmlns="http://www.w3.org/2000/svg">
 <g id="g2402" transform="matrix(0.5516406,0,0,0.5516406,-0.141648,5.8045181)"><g id="breadboard" transform="translate(25.567978,2.8630951)">
 	<path d="M 32.521,33.559 L -23.979,33.559 L -25.221867,32.035821 L -23.979,-2.191 L 31.215133,-3.6671786 L 32.521,-2.191 L 32.521,33.559 z" id="polygon4" transform="translate(0.1694095,0.4401881)"/>
 	<rect height="35.75" id="rect6" style="fill:#1a1a1a" width="56.5" x="-25.037245" y="-3.1576223"/>

--- a/svg/core/icon/basic_resistor.svg
+++ b/svg/core/icon/basic_resistor.svg
@@ -7,7 +7,8 @@
    width="32"
    height="32"
    xml:space="preserve"
-   id="svg2">
+   id="svg2"
+   xmlns="http://www.w3.org/2000/svg">
 <g
    id="icon"
    transform="matrix(0.7456253,0,0,0.7456,0,12.294)">  <!-- needed an id so fritzing could extract the element for either icon or breadboard view -->

--- a/svg/core/icon/basic_servo.svg
+++ b/svg/core/icon/basic_servo.svg
@@ -7,7 +7,8 @@
    x="0px"
    y="0px"
    width="32"
-   height="32">
+   height="32"
+   xmlns="http://www.w3.org/2000/svg">
 
 <g
    id="icon"

--- a/svg/core/icon/basic_toggle_switch.svg
+++ b/svg/core/icon/basic_toggle_switch.svg
@@ -7,7 +7,8 @@
    x="0px"
    y="0px"
    width="32"
-   height="32">
+   height="32"
+   xmlns="http://www.w3.org/2000/svg">
 <rect
    id="connector0terminal"
    x="8.3900003"

--- a/svg/core/icon/batterypack_2xAA.svg
+++ b/svg/core/icon/batterypack_2xAA.svg
@@ -7,7 +7,8 @@
    y="0px"
    width="32px"
    height="32px"
-   viewBox="0 0 32 32">
+   viewBox="0 0 32 32"
+   xmlns="http://www.w3.org/2000/svg">
 <g
    id="icon">
 	<path

--- a/svg/core/icon/ceramic_disk_thermistor.svg
+++ b/svg/core/icon/ceramic_disk_thermistor.svg
@@ -7,7 +7,8 @@
    y="0px"
    width="32px"
    height="32px"
-   viewBox="0 0 32 32">
+   viewBox="0 0 32 32"
+   xmlns="http://www.w3.org/2000/svg">
    <g id="icon"><g
        id="g4"><path
          fill="#8C8C8C"

--- a/svg/core/icon/dc_motor.svg
+++ b/svg/core/icon/dc_motor.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><svg height="32" id="svg2457" version="1.0" width="32">
+<?xml version="1.0" encoding="UTF-8"?><svg height="32" id="svg2457" version="1.0" width="32" xmlns="http://www.w3.org/2000/svg">
   <g id="layer1">
     <g id="breadboard" transform="matrix(0.2663737,0,0,0.2663737,-3.7755054e-2,4.6054375)">
 	<g id="g8">

--- a/svg/core/icon/lm358icon.svg
+++ b/svg/core/icon/lm358icon.svg
@@ -6,7 +6,8 @@
    x="0px"
    y="0px"
    width="32px"
-   height="32px">
+   height="32px"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="icon"
      transform="matrix(0.8,0,0,0.8,0,2.8)">

--- a/svg/core/icon/plain_pcb.svg
+++ b/svg/core/icon/plain_pcb.svg
@@ -3,7 +3,8 @@
    width="32"
    height="32"
    id="svg2524"
-   version="1.0">
+   version="1.0"
+   xmlns="http://www.w3.org/2000/svg">
   <rect
      id="rect2383_2_"
      x="-0.027729571"

--- a/svg/core/icon/potentiometer.svg
+++ b/svg/core/icon/potentiometer.svg
@@ -3,7 +3,8 @@
    width="32"
    height="32"
    id="svg2524"
-   version="1.0">
+   version="1.0"
+   xmlns="http://www.w3.org/2000/svg">
   <g
      id="layer1">
     <g

--- a/svg/core/icon/screw_terminal.svg
+++ b/svg/core/icon/screw_terminal.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1"
 	 id="svg"  x="0px" y="0px" width="32px" height="32px"
-	 viewBox="0 0 32 32">
+	 viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
 <g id="icon">
 	<g>
 		<polygon fill="#254E89" points="31.294,8.113 31.294,1.859 0.071,1.859 0.071,8.113 0.708,8.113 0.708,13.196 0.071,13.196 

--- a/svg/core/schematic/P1000K_diode.svg
+++ b/svg/core/schematic/P1000K_diode.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" x="0px" y="0px" width="8.375px"
-	 height="22.018px" viewBox="0 0 8.375 22.018" enable-background="new 0 0 8.375 22.018" xml:space="preserve">
+	 height="22.018px" viewBox="0 0 8.375 22.018" enable-background="new 0 0 8.375 22.018" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
 <g id="schematic">
 	<line fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" x1="7.787" y1="14.677" x2="4.188" y2="14.677"/>
 	<line fill="none" stroke="#000000" stroke-width="0.7" stroke-linecap="round" x1="4.188" y1="14.677" x2="0.587" y2="14.677"/>


### PR DESCRIPTION
Add missing attribute: 'xmlns="http://www.w3.org/2000/svg"'

This is needed in most browsers to be viewable with `<img src="*.svg">`.

(I'm unsure, if i should create a pull request on nightlyParts or develop. What would be the correct branch?)