### PR TITLE
Fix numbering on DB9 schematic

### DIFF
--- a/svg/core/schematic/sparkfun-connectors_f09g_schematic.svg
+++ b/svg/core/schematic/sparkfun-connectors_f09g_schematic.svg
@@ -32,34 +32,34 @@
 	
 		<line id="connector7pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="43.551" y1="16.624" x2="29.15" y2="16.624"/>
 	<rect id="connector7terminal" x="43.551" y="16.624" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 35.6619 15.574)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">8</text>
+	<text transform="matrix(1 0 0 1 35.6619 15.574)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">6</text>
 	
 		<line id="connector3pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="0.35" y1="16.624" x2="14.75" y2="16.624"/>
 	<rect id="connector3terminal" x="0.35" y="16.624" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 6.8601 15.574)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">4</text>
+	<text transform="matrix(1 0 0 1 6.8601 15.574)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">2</text>
 	
 		<line id="connector8pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="43.551" y1="23.824" x2="29.15" y2="23.824"/>
 	<rect id="connector8terminal" x="43.551" y="23.824" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 35.6619 22.7732)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">9</text>
+	<text transform="matrix(1 0 0 1 35.6619 22.7732)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">7</text>
 	
 		<line id="connector4pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="0.35" y1="23.824" x2="14.75" y2="23.824"/>
 	<rect id="connector4terminal" x="0.35" y="23.824" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 6.8601 22.7732)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">5</text>
+	<text transform="matrix(1 0 0 1 6.8601 22.7732)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">3</text>
 	
 		<line id="connector9pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="43.551" y1="31.024" x2="29.15" y2="31.024"/>
 	<rect id="connector9terminal" x="43.551" y="31.024" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 34.9714 29.9724)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">10</text>
+	<text transform="matrix(1 0 0 1 35.6619 29.9724)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">8</text>
 	
 		<line id="connector5pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="0.35" y1="31.024" x2="14.75" y2="31.024"/>
 	<rect id="connector5terminal" x="0.35" y="31.024" fill="none" width="0" height="0"/>
-	<text transform="matrix(1 0 0 1 6.8601 29.9724)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">6</text>
+	<text transform="matrix(1 0 0 1 6.8601 29.9724)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">4</text>
 	
 		<line id="connector10pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="43.551" y1="38.223" x2="29.15" y2="38.223"/>
 	<rect id="connector10terminal" x="43.551" y="38.223" fill="none" width="0" height="0.001"/>
-	<text transform="matrix(1 0 0 1 34.9714 37.1736)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">11</text>
+	<text transform="matrix(1 0 0 1 35.6619 37.1736)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">9</text>
 	
 		<line id="connector6pin" fill="none" stroke="#787878" stroke-width="0.75" stroke-linecap="round" x1="0.35" y1="38.223" x2="14.75" y2="38.223"/>
 	<rect id="connector6terminal" x="0.35" y="38.223" fill="none" width="0" height="0.001"/>
-	<text transform="matrix(1 0 0 1 6.8601 37.1736)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">7</text>
+	<text transform="matrix(1 0 0 1 6.8601 37.1736)" fill="#8C8C8C" font-family="'DroidSans'" font-size="2.5">5</text>
 </g>
 </svg>


### PR DESCRIPTION
DB9 connector schematic has nonsense numbering in the SVG (presumably from copying the graphic used for the DB25).