### PR TITLE
added spice line to batteries

### DIFF
--- a/core/4 x AAA Battery Mount.fzp
+++ b/core/4 x AAA Battery Mount.fzp
@@ -15,6 +15,7 @@
         <property name="voltage">4.8V</property>
     </properties>
     <description>A 4 x AAA battery pack (4.8 Volts with recharables)</description>
+    <spice><line>V{instanceTitle} {net connector1} {net connector0} DC {voltage}</line></spice>
     <views>
         <iconView>
             <layers image="icon/batterypack_2xAA.svg">

--- a/core/Battery block 9V.fzp
+++ b/core/Battery block 9V.fzp
@@ -14,6 +14,7 @@
         <property name="voltage" showInLabel="yes">9V</property>
     </properties>
     <description>Your standard 9 Volts battery block</description>
+    <spice><line>V{instanceTitle} {net connector1} {net connector0} DC {voltage}</line></spice>
     <views>
         <iconView>
             <layers image="icon/Battery_block_9V82.svg">

--- a/core/battery-AA.fzp
+++ b/core/battery-AA.fzp
@@ -14,6 +14,7 @@
         <property name="voltage" showInLabel="yes">3V</property>
     </properties>
     <description>Your standard 2x AA battery pack (3 Volts)</description>
+    <spice><line>V{instanceTitle} {net connector1} {net connector0} DC {voltage}</line></spice>
     <views>
         <iconView>
             <layers image="icon/batterypack_2xAA.svg">


### PR DESCRIPTION
This is necessary for a future simulator. The only power supply that has a spice line is the DC power symbol, which only works for the schematic view.
