### PR TITLE
SparkFun RJ45 breakout board

### DIFF
--- a/bins/more/sparkfun-connectors.fzb
+++ b/bins/more/sparkfun-connectors.fzb
@@ -514,7 +514,7 @@
 </iconView>
 </views>
 </instance>
-<instance moduleIdRef='SparkFun-Connectors-RJ45-8-PTH' modelIndex='89'>
+<instance moduleIdRef='SparkFun-Connectors-RJ45-8-PTH_fix' modelIndex='89'>
 <views>
 <iconView layer='icon'>
 <geometry z='-1' x='-1' y='-1'></geometry>

--- a/core/sparkfun-connectors-rj45-8-breakout-bob00716.fzp
+++ b/core/sparkfun-connectors-rj45-8-breakout-bob00716.fzp
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module fritzingVersion="0.9.10" moduleId="sparkfun-connectors-rj45-8-breakout-bob00716">
+	<version>1</version>
+	<date>2022-07-09</date>
+	<label>U</label>
+	<author>www.fritzing.org</author>
+	<description>&lt;b&gt;RJ45 Jack&lt;/b&gt;
+Simple RJ45, 8-pin connection - connector for common Cat5, Cat5e, and Cat6 Ethernet cables. Footprint not yet proven in production. Connector sku is PRT-00643; Breakout PCB sku is BOB-00716.</description>
+	<title>RJ45 Jack</title>
+	<tags>
+		<tag>PTH</tag>
+		<tag>RJ45-8</tag>
+	</tags>
+	<properties>
+		<property name="package">rj45-8</property>
+		<property name="target">RJ-45 breakout</property>
+		<property name="family">sparkfun RJ-XX Jack</property>
+		<property name="variant">pth</property>
+	</properties>
+	<views>
+		<breadboardView>
+			<layers image="breadboard/sparkfun-connectors_rj45-8-breakout_breadboard.svg">
+				<layer layerId="breadboard"/>
+			</layers>
+		</breadboardView>
+		<schematicView>
+			<layers image="schematic/sparkfun-connectors_rj45-8_schematic.svg">
+				<layer layerId="schematic"/>
+			</layers>
+		</schematicView>
+		<pcbView>
+			<layers image="pcb/sparkfun-connectors_rj45-8_pcb_fix.svg">
+				<layer layerId="copper1"/>
+				<layer layerId="silkscreen"/>
+				<layer layerId="copper0"/>
+			</layers>
+		</pcbView>
+		<iconView>
+			<layers image="icon/RJ45-8.svg">
+				<layer layerId="icon"/>
+			</layers>
+		</iconView>
+	</views>
+	<connectors>
+		<connector id="connector0" name="1" type="male">
+			<description>1</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector0pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector0pin" terminalId="connector0terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector0pad"/>
+					<p layer="copper1" svgId="connector0pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector1" name="2" type="male">
+			<description>2</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector1pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector1pin" terminalId="connector1terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector1pad"/>
+					<p layer="copper1" svgId="connector1pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector2" name="3" type="male">
+			<description>3</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector2pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector2pin" terminalId="connector2terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector2pad"/>
+					<p layer="copper1" svgId="connector2pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector3" name="4" type="male">
+			<description>4</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector3pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector3pin" terminalId="connector3terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector3pad"/>
+					<p layer="copper1" svgId="connector3pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector4" name="5" type="male">
+			<description>5</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector4pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector4pin" terminalId="connector4terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector4pad"/>
+					<p layer="copper1" svgId="connector4pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector5" name="6" type="male">
+			<description>6</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector5pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector5pin" terminalId="connector5terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector5pad"/>
+					<p layer="copper1" svgId="connector5pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector6" name="7" type="male">
+			<description>7</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector6pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector6pin" terminalId="connector6terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector6pad"/>
+					<p layer="copper1" svgId="connector6pad"/>
+				</pcbView>
+			</views>
+		</connector>
+		<connector id="connector7" name="8" type="male">
+			<description>8</description>
+			<views>
+				<breadboardView>
+					<p layer="breadboard" svgId="connector7pin"/>
+				</breadboardView>
+				<schematicView>
+					<p layer="schematic" svgId="connector7pin" terminalId="connector7terminal"/>
+				</schematicView>
+				<pcbView>
+					<p layer="copper0" svgId="connector7pad"/>
+					<p layer="copper1" svgId="connector7pad"/>
+				</pcbView>
+			</views>
+		</connector>
+	</connectors>
+	<buses></buses>
+</module>

--- a/svg/core/breadboard/sparkfun-connectors_rj45-8-breakout_breadboard.svg
+++ b/svg/core/breadboard/sparkfun-connectors_rj45-8-breakout_breadboard.svg
@@ -1,0 +1,912 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="0.80000812in"
+   height="0.94170094in"
+   viewBox="0 0 20.320207 23.919204"
+   version="1.1"
+   id="svg3046">
+  <g
+     id="breadboard">
+    <path
+       id="x-boardoutline"
+       style="fill:#c62717;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:square"
+       d="M -4.977409e-7,2.3229362e-6 V 16.510105 H 20.320206 V 2.3229362e-6 Z M 1.2702059,0.76222985 A 0.50800002,0.50800002 0 0 1 1.7781847,1.2702087 0.50800002,0.50800002 0 0 1 1.2702059,1.7781875 0.50800002,0.50800002 0 0 1 0.76222439,1.2702087 0.50800002,0.50800002 0 0 1 1.2702059,0.76222985 Z m 2.5398967,0 A 0.50800002,0.50800002 0 0 1 4.3180815,1.2702087 0.50800002,0.50800002 0 0 1 3.8101026,1.7781875 0.50800002,0.50800002 0 0 1 3.3021212,1.2702087 0.50800002,0.50800002 0 0 1 3.8101026,0.76222985 Z m 2.5398968,0 A 0.50800002,0.50800002 0 0 1 6.8579782,1.2702087 0.50800002,0.50800002 0 0 1 6.3499994,1.7781875 0.50800002,0.50800002 0 0 1 5.8420179,1.2702087 0.50800002,0.50800002 0 0 1 6.3499994,0.76222985 Z m 2.5404127,0 A 0.50800002,0.50800002 0 0 1 9.398391,1.2702087 0.50800002,0.50800002 0 0 1 8.8904121,1.7781875 0.50800002,0.50800002 0 0 1 8.3824333,1.2702087 0.50800002,0.50800002 0 0 1 8.8904121,0.76222985 Z m 2.5398969,0 A 0.50800002,0.50800002 0 0 1 11.938288,1.2702087 0.50800002,0.50800002 0 0 1 11.430309,1.7781875 0.50800002,0.50800002 0 0 1 10.92233,1.2702087 0.50800002,0.50800002 0 0 1 11.430309,0.76222985 Z m 2.539897,0 A 0.50800002,0.50800002 0 0 1 14.478185,1.2702087 0.50800002,0.50800002 0 0 1 13.970206,1.7781875 0.50800002,0.50800002 0 0 1 13.462224,1.2702087 0.50800002,0.50800002 0 0 1 13.970206,0.76222985 Z m 2.539896,0 A 0.50800002,0.50800002 0 0 1 17.018081,1.2702087 0.50800002,0.50800002 0 0 1 16.510102,1.7781875 0.50800002,0.50800002 0 0 1 16.002121,1.2702087 0.50800002,0.50800002 0 0 1 16.510102,0.76222985 Z m 2.539897,0 A 0.50800002,0.50800002 0 0 1 19.557978,1.2702087 0.50800002,0.50800002 0 0 1 19.049999,1.7781875 0.50800002,0.50800002 0 0 1 18.542018,1.2702087 0.50800002,0.50800002 0 0 1 19.049999,0.76222985 Z" />
+    <g
+       id="x-silkscreen">
+      <g
+         id="x-name">
+        <path
+           d="m 19.517054,14.949814 -0.41124,0.28786"
+           id="path780"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.517054,15.443294 h -0.8636 v -0.32899 l 0.04112,-0.08225 0.04112,-0.04112 0.08225,-0.04112 h 0.12337 l 0.08225,0.04112 0.04112,0.04112 0.04113,0.08225 v 0.32899"
+           id="path782"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.653454,14.332954 h 0.61685 l 0.12337,0.04112 0.08225,0.08225 0.04113,0.12337 v 0.08225"
+           id="path784"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.941314,13.551604 h 0.57574"
+           id="path786"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.612324,13.757214 0.61686,0.20562 v -0.53461"
+           id="path788"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.653454,12.688004 v 0.41123 l 0.41123,0.04113 -0.04112,-0.04113 -0.04112,-0.08224 v -0.20562 l 0.04112,-0.08225 0.04112,-0.04112 0.08225,-0.04113 h 0.20562 l 0.08225,0.04113 0.04112,0.04112 0.04113,0.08225 v 0.20562 l -0.04113,0.08224 -0.04112,0.04113"
+           id="path790"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.064684,11.330914 0.04113,-0.12337 0.04112,-0.04113 0.08225,-0.04112 h 0.12337 l 0.08225,0.04112 0.04112,0.04113 0.04113,0.08225 v 0.32899 h -0.8636 v -0.28787 l 0.04112,-0.08225 0.04112,-0.04112 0.08225,-0.04113 h 0.08225 l 0.08225,0.04113 0.04112,0.04112 0.04112,0.08225 v 0.28787"
+           id="path792"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.517054,10.755184 h -0.57574"
+           id="path794"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.105814,10.755184 -0.08225,-0.04113 -0.04112,-0.04112 -0.04113,-0.08225 v -0.08225"
+           id="path796"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.475924,9.8915837 0.04113,0.08224 v 0.1645003 l -0.04113,0.08225 -0.08225,0.04112 h -0.32899 l -0.08224,-0.04112 -0.04113,-0.08225 V 9.9738237 l 0.04113,-0.08224 0.08224,-0.04113 h 0.08225 l 0.08225,0.4112403"
+           id="path798"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.517054,9.1102238 h -0.45237 l -0.08224,0.04113 -0.04113,0.08225 v 0.16449 l 0.04113,0.08225"
+           id="path800"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.475924,9.1102238 0.04113,0.08225 v 0.20562 l -0.04113,0.08225 -0.08225,0.04112 h -0.08224 l -0.08225,-0.04112 -0.04112,-0.08225 v -0.20562 l -0.04113,-0.08225"
+           id="path802"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.517054,8.6989938 h -0.8636"
+           id="path804"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.188064,8.6167438 0.32899,-0.24674"
+           id="path806"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.941314,8.3700038 0.32899,0.32899"
+           id="path808"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.517054,7.8765138 -0.04113,0.08225 -0.04112,0.04112 -0.08225,0.04113 h -0.24674 l -0.08225,-0.04113 -0.04112,-0.04112 -0.04113,-0.08225 v -0.12337 l 0.04113,-0.08225 0.04112,-0.04112 0.08225,-0.04113 h 0.24674 l 0.08225,0.04113 0.04112,0.04112 0.04113,0.08225 v 0.12337"
+           id="path810"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.941314,6.8484139 h 0.57574"
+           id="path812"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.941314,7.2185338 h 0.45236 l 0.08225,-0.04112 0.04113,-0.08225 V 6.9717939 l -0.04113,-0.08225 -0.04112,-0.04113"
+           id="path814"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.941314,6.5605539 v -0.32899"
+           id="path816"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 18.653454,6.4371839 h 0.74022 l 0.08225,-0.04113 0.04113,-0.08224 v -0.08225"
+           id="path818"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1524;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <g
+         id="x-numbers">
+        <path
+           d="M 1.8537744,2.736672 V 3.353534"
+           id="path830"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 1.8537744,3.045101 H 0.77427444 l 0.15420999,0.102809 0.10280997,0.10281 0.0514,0.102814"
+           id="path832"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 3.4170743,3.353534 -0.0514,-0.05141 -0.0514,-0.102809 V 2.942291 l 0.0514,-0.102809 0.0514,-0.051405 0.10281,-0.051405 h 0.10281 l 0.15422,0.051405 0.61686,0.616857 V 2.736672"
+           id="path842"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 5.8542742,3.404934 V 2.736672 l 0.41123,0.359834 V 2.942291 l 0.05141,-0.102809 0.0514,-0.051405 0.10281,-0.051405 h 0.25703 l 0.10281,0.051405 0.0514,0.051405 0.05141,0.102809 V 3.25072 l -0.05141,0.102814 -0.0514,0.0514"
+           id="path852"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 8.7541041,2.839482 h 0.71967"
+           id="path862"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 8.3428641,3.096506 0.77107,0.257028 V 2.685268"
+           id="path864"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 10.934274,2.788077 v 0.514047 l 0.51404,0.05141 -0.0514,-0.05141 -0.05141,-0.102809 V 2.942291 l 0.05141,-0.102809 0.0514,-0.051405 0.10281,-0.051405 h 0.25703 l 0.10281,0.051405 0.0514,0.051405 0.05141,0.102809 v 0.257024 l -0.05141,0.102809 -0.0514,0.05141"
+           id="path874"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 13.474274,2.839482 v 0.205619 l 0.0514,0.102809 0.0514,0.051405 0.15422,0.102809 0.20562,0.05141 h 0.41124 l 0.10281,-0.05141 0.0514,-0.051404 0.05141,-0.10281 V 2.942291 l -0.05141,-0.102809 -0.0514,-0.051405 -0.10281,-0.051405 h -0.25703 l -0.10281,0.051405 -0.0514,0.051405 -0.05141,0.102809 V 3.14791 l 0.05141,0.10281 0.0514,0.051404 0.10281,0.05141"
+           id="path884"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 16.014274,3.404934 V 2.685268 l 1.0795,0.462642"
+           id="path894"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 19.016914,3.14791 -0.05141,0.10281 -0.0514,0.051404 -0.10281,0.05141 h -0.05141 l -0.10281,-0.05141 -0.0514,-0.051404 -0.0514,-0.10281 V 2.942291 l 0.0514,-0.102809 0.0514,-0.051405 0.10281,-0.051405 h 0.05141 l 0.10281,0.051405 0.0514,0.051405 0.05141,0.102809 V 3.14791 l 0.0514,0.10281 0.05141,0.051404 0.10281,0.05141 h 0.20562 l 0.10281,-0.05141 0.0514,-0.051404 0.05141,-0.10281 V 2.942291 l -0.05141,-0.102809 -0.0514,-0.051405 -0.10281,-0.051405 h -0.20562 l -0.10281,0.051405 -0.05141,0.051405 -0.0514,0.102809"
+           id="path904"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.1905;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <g
+         id="x-outlines">
+        <path
+           d="m 19.685174,2.539974 h -1.27"
+           id="path934"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 17.780174,1.9049741 0.635,0.6349999"
+           id="path936"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 18.415174,-2.5869944e-5 17.780174,0.6349741"
+           id="path938"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 20.320174,1.9049741 -0.635,0.6349999"
+           id="path940"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           d="M 19.685174,-2.5869944e-5 20.320174,0.6349741"
+           id="path944"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 1.9051744,2.539974 H 0.63517444"
+           id="path948"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 1.7446636e-4,1.9049741 0.63517444,2.539974"
+           id="path950"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 0.63517444,-2.5869944e-5 1.7446636e-4,0.6349741"
+           id="path952"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 3.1751743,2.539974 2.5401744,1.9049741"
+           id="path956"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 4.4451743,2.539974 h -1.27"
+           id="path958"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 5.0801743,1.9049741 -0.635,0.6349999"
+           id="path960"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 4.4451743,-2.5869944e-5 5.0801743,0.6349741"
+           id="path962"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 2.5401744,0.6349741 3.1751743,-2.5869944e-5"
+           id="path966"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 2.5401744,1.9049741 -0.635,0.6349999"
+           id="path968"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 1.9051744,-2.5869944e-5 2.5401744,0.6349741"
+           id="path970"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 9.5251741,2.539974 h -1.27"
+           id="path974"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 7.6201742,1.9049741 8.2551741,2.539974"
+           id="path976"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 8.2551741,-2.5869944e-5 7.6201742,0.6349741"
+           id="path978"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 5.7151742,2.539974 5.0801743,1.9049741"
+           id="path980"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 6.9851742,2.539974 h -1.27"
+           id="path982"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 7.6201742,1.9049741 -0.635,0.6349999"
+           id="path984"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 6.9851742,-2.5869944e-5 7.6201742,0.6349741"
+           id="path986"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 5.0801743,0.6349741 5.7151742,-2.5869944e-5"
+           id="path990"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 10.795174,2.539974 -0.635,-0.6349999"
+           id="path992"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 12.065174,2.539974 h -1.27"
+           id="path994"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 12.700174,1.9049741 -0.635,0.6349999"
+           id="path996"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 12.065174,-2.5869944e-5 12.700174,0.6349741"
+           id="path998"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 10.160174,0.6349741 0.635,-0.634999969944"
+           id="path1002"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 10.160174,1.9049741 9.5251741,2.539974"
+           id="path1004"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 9.5251741,-2.5869944e-5 10.160174,0.6349741"
+           id="path1006"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 17.145174,2.539974 h -1.27"
+           id="path1010"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 15.240174,1.9049741 0.635,0.6349999"
+           id="path1012"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 15.875174,-2.5869944e-5 15.240174,0.6349741"
+           id="path1014"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 13.335174,2.539974 -0.635,-0.6349999"
+           id="path1016"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 14.605174,2.539974 h -1.27"
+           id="path1018"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 15.240174,1.9049741 -0.635,0.6349999"
+           id="path1020"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 14.605174,-2.5869944e-5 15.240174,0.6349741"
+           id="path1022"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 12.700174,0.6349741 0.635,-0.634999969944"
+           id="path1026"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="m 17.780174,1.9049741 -0.635,0.6349999"
+           id="path1028"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           d="M 17.145174,-2.5869944e-5 17.780174,0.6349741"
+           id="path1030"
+           style="fill:none;fill-opacity:0;stroke:#ffffff;stroke-width:0.2032;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <g
+           id="g1034"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+        <g
+           id="g1036"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+        <g
+           id="g1038"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+        <g
+           id="g1040"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+        <g
+           id="g1042"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+        <g
+           id="g1044"
+           style="fill:#f2eda1;fill-opacity:0;stroke:#ffffff;stroke-width:203200;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           transform="matrix(9.9999996e-7,0,0,9.9999996e-7,-138.34092,-96.748622)" />
+      </g>
+    </g>
+    <g
+       id="x-contacts">
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector0pin"
+         cx="1.270175"
+         cy="1.2699821"
+         r="0.66039997" />
+      <rect
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         height="1.3207999"
+         x="0.60977459"
+         y="0.60958171"
+         width="1.3207999"
+         id="rect5811" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector1pin"
+         cx="3.8101759"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector2pin"
+         cx="6.3501768"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector3pin"
+         cx="8.8901777"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector4pin"
+         cx="11.430171"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector5pin"
+         cx="13.970172"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector6pin"
+         cx="16.510172"
+         cy="1.2699821"
+         r="0.66039997" />
+      <circle
+         style="fill:none;fill-opacity:0.528226;stroke:#9a916c;stroke-width:0.3048;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="connector7pin"
+         cx="19.050173"
+         cy="1.2699821"
+         r="0.66039997" />
+    </g>
+    <g
+       id="x-rj45_jack"
+       transform="matrix(0.0254,0,0,0.0254,2.016576,3.86837)">
+      <rect
+         width="607.98602"
+         x="16.611099"
+         y="90.277802"
+         fill="#1a1a1a"
+         height="453.76401"
+         id="rect6" />
+      <g
+         id="g162">
+        <g
+           enable-background="new    "
+           id="g160">
+          <g
+             id="g158">
+            <polyline
+               fill="#b3b3b3"
+               points="32.6806,779.903,32.6806,739.722,167.306,739.722,167.306,779.903,32.6806,779.903"
+               id="polyline8" />
+            <polyline
+               fill="#b3b3b3"
+               points="32.6806,739.722,32.6806,545.653,608.556,545.653,608.556,623.778,608.556,628.514,608.681,628.514,608.681,658.958,608.556,658.958,608.556,663.778,608.556,739.722,473.944,739.722,608.556,739.722,608.556,779.903,473.944,779.903,395.292,779.903,395.292,784.764,245.931,784.764,245.931,779.903,167.306,779.903,167.306,739.722,32.6806,739.722"
+               id="polyline10" />
+            <polyline
+               fill="#b3b3b3"
+               points="624.542,538.208,16.5556,538.208,16.5556,789.403,624.542,789.403,624.542,789.333,16.5556,789.333,16.5556,786.208,624.542,786.208,618.431,786.208,618.431,705.597,624.542,705.597,624.542,538.208"
+               id="polyline12" />
+            <polyline
+               fill="#333333"
+               points="595.542,658.958,595.542,734.778,464.292,734.778,464.292,744.708,463.931,744.708,463.931,753.333,395.292,753.333,395.292,776.403,395.292,779.903,473.944,779.903,473.944,739.722,608.556,739.722,608.556,663.778,595.542,663.778,595.542,658.958"
+               id="polyline14" />
+            <polyline
+               fill="#333333"
+               points="608.556,545.653,32.6806,545.653,32.6806,739.722,167.306,739.722,167.306,779.903,245.931,779.903,245.931,753.333,177.306,753.333,177.306,744.708,176.931,744.708,176.931,734.778,45.8056,734.778,45.8056,663.778,32.6806,663.778,32.6806,623.778,45.8056,623.778,45.8056,552.694,131.931,552.694,149.306,552.694,154.667,552.694,158.056,552.694,160.681,552.694,165.931,552.694,168.681,552.694,172.042,552.694,176.931,552.694,194.306,552.694,199.681,552.694,203.056,552.694,205.681,552.694,210.931,552.694,213.681,552.694,217.056,552.694,221.931,552.694,239.306,552.694,244.681,552.694,248.056,552.694,250.806,552.694,255.931,552.694,258.556,552.694,262.056,552.694,266.931,552.694,284.292,552.694,289.681,552.694,293.056,552.694,295.806,552.694,300.931,552.694,303.556,552.694,307.056,552.694,311.931,552.694,329.292,552.694,334.667,552.694,338.167,552.694,340.806,552.694,345.931,552.694,348.667,552.694,352.042,552.694,356.944,552.694,374.306,552.694,379.667,552.694,383.167,552.694,385.806,552.694,390.917,552.694,393.667,552.694,397.056,552.694,401.917,552.694,419.306,552.694,424.681,552.694,428.056,552.694,430.792,552.694,436.042,552.694,438.667,552.694,442.069,552.694,446.917,552.694,464.292,552.694,469.681,552.694,473.042,552.694,475.806,552.694,481.042,552.694,483.681,552.694,487.056,552.694,491.917,552.694,509.306,552.694,595.542,552.694,595.542,628.514,595.542,623.778,608.556,623.778,608.556,545.653"
+               id="polyline16" />
+            <polyline
+               points="177.306,753.278,177.306,744.708,463.792,744.708,463.792,753.278,177.306,753.278"
+               id="polyline18" />
+            <polyline
+               points="131.931,734.778,131.931,680.333,149.306,680.333,149.306,734.778,131.931,734.778"
+               id="polyline20" />
+            <polyline
+               points="221.931,744.708,221.931,680.333,239.306,680.333,239.306,744.708,221.931,744.708"
+               id="polyline22" />
+            <polyline
+               points="266.931,744.708,266.931,680.333,284.292,680.333,284.292,744.708,266.931,744.708"
+               id="polyline24" />
+            <polyline
+               points="311.931,744.708,311.931,680.333,329.292,680.333,329.292,744.708,311.931,744.708"
+               id="polyline26" />
+            <polyline
+               points="356.944,744.708,356.944,680.333,374.306,680.333,374.306,744.708,356.944,744.708"
+               id="polyline28" />
+            <polyline
+               points="401.917,744.708,401.917,680.333,419.306,680.333,419.306,744.708,401.917,744.708"
+               id="polyline30" />
+            <polyline
+               points="491.917,734.778,491.917,680.333,509.306,680.333,509.306,734.778,491.917,734.778"
+               id="polyline32" />
+            <polyline
+               points="595.542,552.694,509.306,552.694,509.306,675.639,491.917,675.639,491.917,552.694,487.056,552.694,487.056,656.347,469.681,656.347,469.681,552.694,464.292,552.694,464.292,675.639,446.917,675.639,446.917,552.694,442.069,552.694,442.069,656.347,424.681,656.347,424.681,552.694,419.306,552.694,419.306,675.639,401.917,675.639,401.917,552.694,397.056,552.694,397.056,656.347,379.667,656.347,379.667,552.694,374.306,552.694,374.306,675.639,356.944,675.639,356.944,552.694,352.042,552.694,352.042,656.347,334.667,656.347,334.667,552.694,329.292,552.694,329.292,675.639,311.931,675.639,311.931,552.694,307.056,552.694,307.056,656.347,289.681,656.347,289.681,552.694,284.292,552.694,284.292,675.639,266.931,675.639,266.931,552.694,262.056,552.694,262.056,656.347,244.681,656.347,244.681,552.694,239.306,552.694,239.306,675.639,221.931,675.639,221.931,552.694,217.056,552.694,217.056,656.347,199.681,656.347,199.681,552.694,194.306,552.694,194.306,675.639,176.931,675.639,176.931,552.694,172.042,552.694,172.042,656.347,154.667,656.347,154.667,552.694,149.306,552.694,149.306,675.639,131.931,675.639,131.931,552.694,45.8056,552.694,45.8056,623.778,45.8056,628.514,48.3056,628.514,51.6667,628.514,53.4306,628.514,55.4306,628.514,58.8056,628.514,58.8056,658.958,45.8056,658.958,45.8056,663.778,45.8056,734.778,176.931,734.778,176.931,680.333,194.306,680.333,194.306,744.708,177.306,744.708,177.306,753.333,245.931,753.333,245.931,779.903,245.931,776.403,395.292,776.403,395.292,753.333,463.931,753.333,463.931,744.708,446.917,744.708,446.917,680.333,464.292,680.333,464.292,734.778,595.542,734.778,595.542,658.958,582.417,658.958,582.417,628.514,585.778,628.514,587.806,628.514,589.694,628.514,592.931,628.514,595.542,628.514,595.542,552.694"
+               id="polyline34" />
+            <polyline
+               fill="#1a1a1a"
+               points="463.792,744.708,177.306,744.708,177.306,753.278,463.792,753.278,463.792,744.708"
+               id="polyline36" />
+            <polyline
+               fill="#1a1a1a"
+               points="395.292,776.403,245.931,776.403,245.931,779.903,245.931,784.764,395.292,784.764,395.292,779.903,395.292,776.403"
+               id="polyline38" />
+            <polyline
+               points="608.556,658.958,595.542,658.958,595.542,663.778,608.556,663.778,608.556,658.958"
+               id="polyline40" />
+            <polyline
+               points="608.556,623.778,595.542,623.778,595.542,628.514,596.431,628.514,608.556,628.514,608.556,623.778"
+               id="polyline42" />
+            <polyline
+               points="45.8056,623.778,32.6806,623.778,32.6806,663.778,45.8056,663.778,45.8056,658.958,32.6806,658.958,32.6806,628.514,44.8056,628.514,45.8056,628.514,45.8056,623.778"
+               id="polyline44" />
+            <polyline
+               fill="#cccccc"
+               points="608.681,628.514,608.556,628.514,596.431,628.514,596.431,658.958,582.417,658.958,582.417,628.514,582.417,658.958,595.542,658.958,608.556,658.958,608.681,658.958,608.681,628.514"
+               id="polyline46" />
+            <polyline
+               fill="#b3b3b3"
+               points="596.431,628.514,595.542,628.514,592.931,628.514,592.931,658.958,582.417,658.958,582.417,628.514,582.417,658.958,596.431,658.958,596.431,628.514"
+               id="polyline48" />
+            <polyline
+               fill="#999999"
+               points="592.931,628.514,589.694,628.514,589.694,658.958,582.417,658.958,582.417,628.514,582.417,658.958,592.931,658.958,592.931,628.514"
+               id="polyline50" />
+            <polyline
+               fill="#808080"
+               points="589.694,628.514,587.806,628.514,587.806,658.958,585.778,658.958,585.778,628.514,582.417,628.514,582.417,658.958,589.694,658.958,589.694,628.514"
+               id="polyline52" />
+            <polyline
+               fill="#cccccc"
+               points="587.806,628.514,585.778,628.514,585.778,658.958,587.806,658.958,587.806,628.514"
+               id="polyline54" />
+            <polyline
+               fill="#cccccc"
+               points="44.8056,628.514,32.6806,628.514,32.6806,658.958,45.8056,658.958,58.8056,658.958,44.8056,658.958,44.8056,628.514"
+               id="polyline56" />
+            <polyline
+               fill="#b3b3b3"
+               points="48.3056,628.514,45.8056,628.514,44.8056,628.514,44.8056,658.958,58.8056,658.958,48.3056,658.958,48.3056,628.514"
+               id="polyline58" />
+            <polyline
+               fill="#999999"
+               points="51.6667,628.514,48.3056,628.514,48.3056,658.958,58.8056,658.958,51.6667,658.958,51.6667,628.514"
+               id="polyline60" />
+            <polyline
+               fill="#808080"
+               points="58.8056,628.514,55.4306,628.514,55.4306,658.958,53.4306,658.958,53.4306,628.514,51.6667,628.514,51.6667,658.958,58.8056,658.958,58.8056,628.514"
+               id="polyline62" />
+            <polyline
+               fill="#cccccc"
+               points="55.4306,628.514,53.4306,628.514,53.4306,658.958,55.4306,658.958,55.4306,628.514"
+               id="polyline64" />
+            <polyline
+               fill="#0f0f0f"
+               points="509.306,680.333,491.917,680.333,491.917,734.778,509.306,734.778,509.306,680.333"
+               id="polyline66" />
+            <polyline
+               fill="#252525"
+               points="464.292,734.778,463.931,734.778,463.931,744.708,464.292,744.708,464.292,734.778"
+               id="polyline68" />
+            <polyline
+               fill="#0f0f0f"
+               points="464.292,680.333,446.917,680.333,446.917,744.708,463.931,744.708,463.931,734.778,464.292,734.778,464.292,680.333"
+               id="polyline70" />
+            <polyline
+               fill="#0f0f0f"
+               points="419.306,680.333,401.917,680.333,401.917,744.708,419.306,744.708,419.306,680.333"
+               id="polyline72" />
+            <polyline
+               fill="#0f0f0f"
+               points="374.306,680.333,356.944,680.333,356.944,744.708,374.306,744.708,374.306,680.333"
+               id="polyline74" />
+            <polyline
+               fill="#0f0f0f"
+               points="329.292,680.333,311.931,680.333,311.931,744.708,329.292,744.708,329.292,680.333"
+               id="polyline76" />
+            <polyline
+               fill="#0f0f0f"
+               points="284.292,680.333,266.931,680.333,266.931,744.708,284.292,744.708,284.292,680.333"
+               id="polyline78" />
+            <polyline
+               fill="#0f0f0f"
+               points="239.306,680.333,221.931,680.333,221.931,744.708,239.306,744.708,239.306,680.333"
+               id="polyline80" />
+            <polyline
+               fill="#252525"
+               points="177.306,734.778,176.931,734.778,176.931,744.708,177.306,744.708,177.306,734.778"
+               id="polyline82" />
+            <polyline
+               fill="#0f0f0f"
+               points="194.306,680.333,176.931,680.333,176.931,734.778,177.306,734.778,177.306,744.708,194.306,744.708,194.306,680.333"
+               id="polyline84" />
+            <polyline
+               fill="#0f0f0f"
+               points="149.306,680.333,131.931,680.333,131.931,734.778,149.306,734.778,149.306,680.333"
+               id="polyline86" />
+            <polyline
+               fill="#0d0d0d"
+               points="509.306,552.694,491.917,552.694,491.917,675.639,509.306,675.639,509.306,552.694"
+               id="polyline88" />
+            <polyline
+               fill="#0d0d0d"
+               points="464.292,552.694,446.917,552.694,446.917,675.639,464.292,675.639,464.292,552.694"
+               id="polyline90" />
+            <polyline
+               fill="#0d0d0d"
+               points="419.306,552.694,401.917,552.694,401.917,675.639,419.306,675.639,419.306,552.694"
+               id="polyline92" />
+            <polyline
+               fill="#0d0d0d"
+               points="374.306,552.694,356.944,552.694,356.944,675.639,374.306,675.639,374.306,552.694"
+               id="polyline94" />
+            <polyline
+               fill="#0d0d0d"
+               points="329.292,552.694,311.931,552.694,311.931,675.639,329.292,675.639,329.292,552.694"
+               id="polyline96" />
+            <polyline
+               fill="#0d0d0d"
+               points="284.292,552.694,266.931,552.694,266.931,675.639,284.292,675.639,284.292,552.694"
+               id="polyline98" />
+            <polyline
+               fill="#0d0d0d"
+               points="239.306,552.694,221.931,552.694,221.931,675.639,239.306,675.639,239.306,552.694"
+               id="polyline100" />
+            <polyline
+               fill="#0d0d0d"
+               points="194.306,552.694,176.931,552.694,176.931,675.639,194.306,675.639,194.306,552.694"
+               id="polyline102" />
+            <polyline
+               fill="#0d0d0d"
+               points="149.306,552.694,131.931,552.694,131.931,675.639,149.306,675.639,149.306,552.694"
+               id="polyline104" />
+            <polyline
+               fill="#6f4813"
+               points="487.056,552.694,483.681,552.694,483.681,656.347,473.042,656.347,473.042,552.694,469.681,552.694,469.681,656.347,487.056,656.347,487.056,552.694"
+               id="polyline106" />
+            <polyline
+               fill="#6f4813"
+               points="442.069,552.694,438.667,552.694,438.667,656.347,428.056,656.347,428.056,552.694,424.681,552.694,424.681,656.347,442.069,656.347,442.069,552.694"
+               id="polyline108" />
+            <polyline
+               fill="#6f4813"
+               points="397.056,552.694,393.667,552.694,393.667,656.347,383.167,656.347,383.167,552.694,379.667,552.694,379.667,656.347,397.056,656.347,397.056,552.694"
+               id="polyline110" />
+            <polyline
+               fill="#6f4813"
+               points="352.042,552.694,348.667,552.694,348.667,656.347,338.167,656.347,338.167,552.694,334.667,552.694,334.667,656.347,352.042,656.347,352.042,552.694"
+               id="polyline112" />
+            <polyline
+               fill="#6f4813"
+               points="307.056,552.694,303.556,552.694,303.556,656.347,293.056,656.347,293.056,552.694,289.681,552.694,289.681,656.347,307.056,656.347,307.056,552.694"
+               id="polyline114" />
+            <polyline
+               fill="#6f4813"
+               points="262.056,552.694,258.556,552.694,258.556,656.347,248.056,656.347,248.056,552.694,244.681,552.694,244.681,656.347,262.056,656.347,262.056,552.694"
+               id="polyline116" />
+            <polyline
+               fill="#6f4813"
+               points="217.056,552.694,213.681,552.694,213.681,656.347,203.056,656.347,203.056,552.694,199.681,552.694,199.681,656.347,217.056,656.347,217.056,552.694"
+               id="polyline118" />
+            <polyline
+               fill="#6f4813"
+               points="172.042,552.694,168.681,552.694,168.681,656.347,158.056,656.347,158.056,552.694,154.667,552.694,154.667,656.347,172.042,656.347,172.042,552.694"
+               id="polyline120" />
+            <polyline
+               fill="#78592e"
+               points="483.681,552.694,481.042,552.694,481.042,656.347,475.806,656.347,475.806,552.694,473.042,552.694,473.042,656.347,483.681,656.347,483.681,552.694"
+               id="polyline122" />
+            <polyline
+               fill="#78592e"
+               points="438.667,552.694,436.042,552.694,436.042,656.347,430.792,656.347,430.792,552.694,428.056,552.694,428.056,656.347,438.667,656.347,438.667,552.694"
+               id="polyline124" />
+            <polyline
+               fill="#78592e"
+               points="393.667,552.694,390.917,552.694,390.917,656.347,385.806,656.347,385.806,552.694,383.167,552.694,383.167,656.347,393.667,656.347,393.667,552.694"
+               id="polyline126" />
+            <polyline
+               fill="#78592e"
+               points="348.667,552.694,345.931,552.694,345.931,656.347,340.806,656.347,340.806,552.694,338.167,552.694,338.167,656.347,348.667,656.347,348.667,552.694"
+               id="polyline128" />
+            <polyline
+               fill="#78592e"
+               points="303.556,552.694,300.931,552.694,300.931,656.347,295.806,656.347,295.806,552.694,293.056,552.694,293.056,656.347,303.556,656.347,303.556,552.694"
+               id="polyline130" />
+            <polyline
+               fill="#78592e"
+               points="258.556,552.694,255.931,552.694,255.931,656.347,250.806,656.347,250.806,552.694,248.056,552.694,248.056,656.347,258.556,656.347,258.556,552.694"
+               id="polyline132" />
+            <polyline
+               fill="#78592e"
+               points="213.681,552.694,210.931,552.694,210.931,656.347,205.681,656.347,205.681,552.694,203.056,552.694,203.056,656.347,213.681,656.347,213.681,552.694"
+               id="polyline134" />
+            <polyline
+               fill="#78592e"
+               points="168.681,552.694,165.931,552.694,165.931,656.347,160.681,656.347,160.681,552.694,158.056,552.694,158.056,656.347,168.681,656.347,168.681,552.694"
+               id="polyline136" />
+            <polyline
+               fill="#81694a"
+               points="481.042,552.694,475.806,552.694,475.806,656.347,481.042,656.347,481.042,552.694"
+               id="polyline138" />
+            <polyline
+               fill="#81694a"
+               points="436.042,552.694,430.792,552.694,430.792,656.347,436.042,656.347,436.042,552.694"
+               id="polyline140" />
+            <polyline
+               fill="#81694a"
+               points="390.917,552.694,385.806,552.694,385.806,656.347,390.917,656.347,390.917,552.694"
+               id="polyline142" />
+            <polyline
+               fill="#81694a"
+               points="345.931,552.694,340.806,552.694,340.806,656.347,345.931,656.347,345.931,552.694"
+               id="polyline144" />
+            <polyline
+               fill="#81694a"
+               points="300.931,552.694,295.806,552.694,295.806,656.347,300.931,656.347,300.931,552.694"
+               id="polyline146" />
+            <polyline
+               fill="#81694a"
+               points="255.931,552.694,250.806,552.694,250.806,656.347,255.931,656.347,255.931,552.694"
+               id="polyline148" />
+            <polyline
+               fill="#81694a"
+               points="210.931,552.694,205.681,552.694,205.681,656.347,210.931,656.347,210.931,552.694"
+               id="polyline150" />
+            <polyline
+               fill="#81694a"
+               points="165.931,552.694,160.681,552.694,160.681,656.347,165.931,656.347,165.931,552.694"
+               id="polyline152" />
+            <polyline
+               fill="#999999"
+               points="624.542,786.208,16.5556,786.208,16.5556,789.333,624.542,789.333,624.542,786.208"
+               id="polyline154" />
+            <polyline
+               fill="#999999"
+               points="624.542,705.597,618.431,705.597,618.431,786.208,624.542,786.208,624.542,705.597"
+               id="polyline156" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g190">
+        <path
+           fill="#b3b3b3"
+           d="m 167.097,408.625 c 0,-5.5 4.5,-9.98611 10.0556,-9.98611 h 36.7917 c 5.5,0 10.0556,4.5 10.0556,9.98611 v 131.236 c 0,5.5 -4.5,9.98611 -10.0556,9.98611 h -36.7917 c -5.5,0 -10.0556,-4.48611 -10.0556,-9.98611 z"
+           id="path164" />
+        <path
+           fill="#b3b3b3"
+           d="m 417.194,408.625 c 0,-5.5 4.5,-9.98611 10.0694,-9.98611 h 36.7778 c 5.5,0 10.0694,4.5 10.0694,9.98611 v 131.236 c 0,5.5 -4.5,9.98611 -10.0694,9.98611 h -36.7778 c -5.5,0 -10.0694,-4.48611 -10.0694,-9.98611 z"
+           id="path166" />
+        <path
+           fill="#cccccc"
+           d="m 167.097,408.625 c 0,-5.5 4.5,-9.98611 10.0556,-9.98611 h 36.7917 c 5.5,0 10.0556,4.5 10.0556,9.98611 v 16.2222 l -56.9169,-2e-4 z"
+           id="path168" />
+        <path
+           fill="#cccccc"
+           d="m 417.194,408.625 c 0,-5.5 4.5,-9.98611 10.0694,-9.98611 h 36.7778 c 5.5,0 10.0694,4.5 10.0694,9.98611 v 16.2222 h -56.9167 z"
+           id="path170" />
+        <rect
+           width="56.916698"
+           x="167.097"
+           y="422.26401"
+           fill="#999999"
+           height="56.430599"
+           id="rect172" />
+        <rect
+           width="56.916698"
+           x="417.194"
+           y="422.26401"
+           fill="#999999"
+           height="56.430599"
+           id="rect174" />
+        <rect
+           width="56.916698"
+           x="167.097"
+           y="457.83301"
+           fill="#b3b3b3"
+           height="53.819401"
+           id="rect176" />
+        <rect
+           width="56.916698"
+           x="417.194"
+           y="457.83301"
+           fill="#b3b3b3"
+           height="53.819401"
+           id="rect178" />
+        <rect
+           width="56.916698"
+           x="167.097"
+           y="482.58301"
+           fill="#cccccc"
+           height="20.4028"
+           id="rect180" />
+        <rect
+           width="56.916698"
+           x="417.194"
+           y="482.58301"
+           fill="#cccccc"
+           height="20.4028"
+           id="rect182" />
+        <rect
+           width="56.916698"
+           x="167.097"
+           y="420.11099"
+           fill="#e6e6e6"
+           height="4.3194399"
+           id="rect184" />
+        <rect
+           width="56.916698"
+           x="167.13901"
+           y="412.51401"
+           fill="#f2f2f2"
+           height="6.7916698"
+           id="rect186" />
+        <path
+           fill="#cccccc"
+           d="m 624.625,393.375 v -383.3611 -10 H 614.6111 L 26.6389,0.0138889 H 16.6111 V 10.013889 393.37489 h 4 v 144.847 l 6.0556,1.1e-4 h 119.819 10 l 0.65278,-9.95833 4.66667,-70.8889 4.66667,-70.8889 c 0.36111,-5.48611 5.16667,-9.97222 10.7083,-9.97222 h 37.0278 c 5.5,0 10.25,4.48611 10.6667,9.97222 l 4.66667,70.8889 4.66667,70.8889 v 0 l 0.66667,9.95833 h 10.0556 151.639 10.0139 l 0.68055,-9.95833 v 0 l 4.80556,-70.8889 4.83333,-70.9028 c 0.31945,-5.48611 5.18056,-9.95833 10.6667,-9.95833 h 36.5139 c 5.5,0 10.2778,4.47222 10.7083,9.95833 l 4.80556,70.9028 4.77778,70.8889 v 0 l 0.68056,9.95833 h 9.97222 119.819 5.98641 V 393.361 Z"
+           id="path188" />
+      </g>
+      <rect
+         width="48.263901"
+         x="16.611099"
+         opacity="0.37"
+         fill="#e6e6e6"
+         height="538.20801"
+         enable-background="new    "
+         id="rect192"
+         y="0" />
+      <rect
+         width="48.222198"
+         x="576.41699"
+         opacity="0.37"
+         fill="#808080"
+         height="538.20801"
+         enable-background="new    "
+         id="rect194"
+         y="0" />
+      <path
+         opacity="0.45"
+         fill="#e6e6e6"
+         enable-background="new    "
+         d="m 195.528,538.208 h -28.4306 c 0,0 0,-122.958 0,-129.583 0,-6.65278 6.01389,-10.0139 10.0556,-10.0139 4.04171,0 18.375,0 18.375,0 z"
+         id="path196" />
+      <path
+         opacity="0.45"
+         fill="#e6e6e6"
+         enable-background="new    "
+         d="m 445.611,538.208 h -28.375 c 0,0 0,-122.958 0,-129.583 0,-6.65278 5.94444,-10.0139 9.98611,-10.0139 4.04167,0 18.3889,0 18.3889,0 z"
+         id="path198" />
+      <path
+         opacity="0.45"
+         fill="#b3b3b3"
+         enable-background="new    "
+         d="m 445.667,538.208 h 28.4444 c 0,0 0,-122.958 0,-129.583 0,-6.65278 -6.04167,-10.0139 -10.0833,-10.0139 -4.04163,0 -18.3611,0 -18.3611,0 z"
+         id="path200" />
+      <path
+         opacity="0.45"
+         fill="#b3b3b3"
+         enable-background="new    "
+         d="m 195.528,538.208 h 28.4861 c 0,0 0,-122.958 0,-129.583 0,-6.65278 -6.01389,-10.0139 -10.0556,-10.0139 -4.04171,0 -18.4306,0 -18.4306,0 z"
+         id="path202" />
+      <rect
+         width="56.916698"
+         x="167.097"
+         opacity="0.76"
+         y="485.61099"
+         fill="#e6e6e6"
+         height="11.2917"
+         enable-background="new    "
+         id="rect204" />
+      <rect
+         width="56.916698"
+         x="417.194"
+         opacity="0.76"
+         y="485.61099"
+         fill="#e6e6e6"
+         height="11.2917"
+         enable-background="new    "
+         id="rect206" />
+      <rect
+         width="56.916698"
+         x="417.194"
+         opacity="0.76"
+         y="420.11099"
+         fill="#e6e6e6"
+         height="4.3194399"
+         enable-background="new    "
+         id="rect208" />
+      <rect
+         width="56.875"
+         x="417.25"
+         opacity="0.76"
+         y="413.97198"
+         fill="#f2f2f2"
+         height="5.6944399"
+         enable-background="new    "
+         id="rect210" />
+      <g
+         id="g222">
+        <g
+           id="g216">
+          <rect
+             width="5.3611102"
+             x="0.152778"
+             y="577.94397"
+             fill="#999999"
+             height="23.5972"
+             id="rect212" />
+          <rect
+             width="5.3611102"
+             x="0.152778"
+             y="577.94397"
+             fill="#999999"
+             height="23.5972"
+             id="rect214" />
+        </g>
+        <path
+           fill="#999999"
+           d="m 16.5556,667.403 c 0,0 -9.13889,-41.5417 -10.875,-65.8472 l -5.527822,2e-4 c 1.73611,24.3056 10.875,65.8472 10.875,65.8472 0,0 3.52778,20.7917 5.51389,26.4306 C 16.5556,680.375 16.5556,667.403 16.5556,667.403 Z"
+           id="path218" />
+        <path
+           fill="#cccccc"
+           d="m 16.5556,643.958 c 0,0 -9.29167,-41.7083 -11.0278,-66.0139 L 0,577.944 c 1.73611,24.3056 11.0278,66.0139 11.0278,66.0139 0,0 3.52778,20.7917 5.51389,26.4306 C 16.5556,656.944 16.5556,643.958 16.5556,643.958 Z"
+           id="path220" />
+      </g>
+      <g
+         id="g234">
+        <g
+           id="g228">
+          <rect
+             width="5.3611102"
+             x="635.70801"
+             y="577.94397"
+             fill="#999999"
+             height="23.5972"
+             id="rect224" />
+          <rect
+             width="5.3611102"
+             x="635.70801"
+             y="577.94397"
+             fill="#999999"
+             height="23.5972"
+             id="rect226" />
+        </g>
+        <path
+           fill="#999999"
+           d="m 624.667,667.403 c 0,0 9.125,-41.5417 10.8611,-65.8472 h 5.51389 c -1.73611,24.3056 -10.8611,65.8472 -10.8611,65.8472 0,0 -3.52778,20.7917 -5.51389,26.4306 0,-13.4586 0,-26.4306 0,-26.4306 z"
+           id="path230" />
+        <path
+           fill="#cccccc"
+           d="m 624.667,643.958 c 0,0 9.30556,-41.7083 11.0417,-66.0139 h 5.51389 c -1.73611,24.3056 -11.0417,66.0139 -11.0417,66.0139 0,0 -3.52778,20.7917 -5.51389,26.4306 0,-13.4446 0,-26.4306 0,-26.4306 z"
+           id="path232" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
A new variant of the SparkFun-Connectors RJ45 part with the [BOB-00716 breakout board](https://www.sparkfun.com/products/716). Also updates the SparkFun-Connectors bin to use the up-to-date version of the original part.

This is my first part, so let me know if I missed anything.