### PR TITLE
Fix labels of LM2596 buck converter module

### DIFF
--- a/svg/core/breadboard/RioRand_LM2596_94ce9810d0922bc731e2f315085d46ab_1_breadboard.svg
+++ b/svg/core/breadboard/RioRand_LM2596_94ce9810d0922bc731e2f315085d46ab_1_breadboard.svg
@@ -1227,7 +1227,7 @@
       id="text4397"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1">ReoRand</text>
+      stroke-width="1">RioRand</text>
     <text
       id="text397"
       y="225.93681"
@@ -1243,22 +1243,20 @@
       font-size="69.9917984"
       y="725.42657"
       id="text399"
-      transform="scale(0.99988282,1.0001172)"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="0.99988282">IN+</text>
+      stroke-width="1">IN-</text>
     <text
       x="1686.0146"
       gorn="0.3.312.0"
       font-size="65"
       y="201.2719"
       id="text401"
-      transform="scale(1.0010234,0.99897764)"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1.00102341">OUT+</text>
+      stroke-width="1">OUT+</text>
     <text
-      transform="matrix(0,-1.0010234,0.99897764,0,0,0)"
+      transform="matrix(0,-1,1,0,0,0)"
       id="text403"
       y="1745.3064"
       font-size="65"
@@ -1266,7 +1264,7 @@
       x="-875.44403"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1.00102341">OUT-</text>
+      stroke-width="1.00">OUT-</text>
     <text
       id="text405"
       y="570.96979"

--- a/svg/core/icon/RioRand_LM2596_94ce9810d0922bc731e2f315085d46ab_1_icon.svg
+++ b/svg/core/icon/RioRand_LM2596_94ce9810d0922bc731e2f315085d46ab_1_icon.svg
@@ -1227,7 +1227,7 @@
       id="text4397"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1">ReoRand</text>
+      stroke-width="1">RioRand</text>
     <text
       id="text397"
       y="225.93681"
@@ -1243,22 +1243,20 @@
       font-size="69.9917984"
       y="725.42657"
       id="text399"
-      transform="scale(0.99988282,1.0001172)"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="0.99988282">IN+</text>
+      stroke-width="1">IN-</text>
     <text
       x="1686.0146"
       gorn="0.3.312.0"
       font-size="65"
       y="201.2719"
       id="text401"
-      transform="scale(1.0010234,0.99897764)"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1.00102341">OUT+</text>
+      stroke-width="1">OUT+</text>
     <text
-      transform="matrix(0,-1.0010234,0.99897764,0,0,0)"
+      transform="matrix(0,-1,1,0,0,0)"
       id="text403"
       y="1745.3064"
       font-size="65"
@@ -1266,7 +1264,7 @@
       x="-875.44403"
       font-family="OCRA"
       fill="#ffffff"
-      stroke-width="1.00102341">OUT-</text>
+      stroke-width="1.00">OUT-</text>
     <text
       id="text405"
       y="570.96979"


### PR DESCRIPTION
There are two typos in the icon and breadboard view of the LM2596 buck converter module:

 * It's ReoRand instead of RioRand.
 * The lower `IN+` Label should be `IN-`

I have an [AZDelivery clone](https://www.amazon.de/dp/B089QJM8KQ) of this, and there are many more from different manufacturers. Probably worth dropping the RioRand name, but that would be for another PR. Same for moving the `OUT-` label.
